### PR TITLE
The Stake Update (dynamic stake order/count + preparations for stakes as items)

### DIFF
--- a/randomizer.lua
+++ b/randomizer.lua
@@ -1885,7 +1885,7 @@ end
 local create_UIBox_notify_alertRef = create_UIBox_notify_alert
 function create_UIBox_notify_alert(_achievement, _type)
     if isAPProfileLoaded() and
-        (_type == "location" or _type == "Booster" or _type == "Tarot" or _type == "Planet" or _type == "Spectral") then
+        (_type == "location" or _type == "Booster" or _type == "Tarot" or _type == "Planet" or _type == "Spectral" or (_type == "Joker" and G.P_CENTERS[_achievement].soul_pos)) then
 
         -- change this sprite in the future
         -- local _atlas = SMODS.Atlas
@@ -1893,7 +1893,7 @@ function create_UIBox_notify_alert(_achievement, _type)
             _type == "Tarot" and G.ASSET_ATLAS["Tarot"] or _type == "Planet" and G.ASSET_ATLAS["Tarot"] or _type ==
                 "Spectral" and G.ASSET_ATLAS["Tarot"] or _type == "Booster" and G.ASSET_ATLAS["Booster"] or _type ==
                 "location" and G.ASSET_ATLAS["rand_ap_logo"] or G.ASSET_ATLAS["icons"]
-
+	
         if not _c then
             if _type == "location" then
                 _c = {
@@ -1916,6 +1916,21 @@ function create_UIBox_notify_alert(_achievement, _type)
         t_s.states.drag.can = false
         t_s.states.hover.can = false
         t_s.states.collide.can = false
+
+	-- second layer for the soul, the hologramm and the legendaries
+	if G.P_CENTERS[_achievement].soul_pos then
+		local _soul_atlas = _achievement == 'c_soul' and G.ASSET_ATLAS["centers"] or G.ASSET_ATLAS["Joker"]
+		local _soul_pos = _achievement == 'c_soul' and {x = 0, y = 1} or G.P_CENTERS[_achievement].soul_pos
+		local _soul_t_s = Sprite(t_s.T.x,t_s.T.y,1.5*(_soul_atlas.px/_soul_atlas.py),1.5,_soul_atlas, _soul_pos)
+		_soul_t_s.states.drag.can = false
+		_soul_t_s.states.hover.can = false
+		_soul_t_s.states.collide.can = false
+		
+		t_s.children.floating_sprite = _soul_t_s
+		t_s.children.floating_sprite.role.draw_major = t_s
+		_soul_t_s.T = t_s.T
+		_soul_t_s.VT = t_s.VT
+	end
 
         local subtext = "Location cleared"
         local name = "Archipelago"

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -1605,8 +1605,8 @@ G.FUNCS.resolve_location_id_to_name = function(id)
 end
 
 function get_shop_location()
-    if G.AP.slot_data["stake" .. tostring(G.GAME.stake) .. "_shop_locations"] then
-        for i, v in ipairs(G.AP.slot_data["stake" .. tostring(G.GAME.stake) .. "_shop_locations"]) do
+    if G.AP.slot_data["stake" .. tostring(G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level) .. "_shop_locations"] then
+        for i, v in ipairs(G.AP.slot_data["stake" .. tostring(G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level) .. "_shop_locations"]) do
             if (tableContains(G.APClient.missing_locations, v)) then
                 G.FUNCS.resolve_location_id_to_name(v)
                 return v
@@ -1627,7 +1627,7 @@ G.FUNCS.select_blind = function(e)
         for k, v in pairs(deck_list) do
             if deck_name == v then
                 G.APClient:LocationScouts({G.AP.id_offset + (64 * k) + (G.GAME.round_resets.ante - 1) * 8 +
-                    (G.GAME.stake - 1)})
+                    (G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level - 1)})
                 break -- break the loop once the correct deck is found
             end
         end
@@ -1823,7 +1823,7 @@ function check_for_unlock(args)
 
             for k, v in pairs(deck_list) do
                 if deck_name == v then
-                    sendLocationCleared(G.AP.id_offset + (64 * k) + (args.ante - 2) * 8 + (G.GAME.stake - 1))
+                    sendLocationCleared(G.AP.id_offset + (64 * k) + (args.ante - 2) * 8 + (G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level - 1))
                     break -- break the loop once the correct deck is found
                 end
             end

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -1918,7 +1918,7 @@ function create_UIBox_notify_alert(_achievement, _type)
         t_s.states.collide.can = false
 
 	-- second layer for the soul, the hologramm and the legendaries
-	if G.P_CENTERS[_achievement].soul_pos then
+	if G.P_CENTERS[_achievement] and G.P_CENTERS[_achievement].soul_pos then
 		local _soul_atlas = _achievement == 'c_soul' and G.ASSET_ATLAS["centers"] or G.ASSET_ATLAS["Joker"]
 		local _soul_pos = _achievement == 'c_soul' and {x = 0, y = 1} or G.P_CENTERS[_achievement].soul_pos
 		local _soul_t_s = Sprite(t_s.T.x,t_s.T.y,1.5*(_soul_atlas.px/_soul_atlas.py),1.5,_soul_atlas, _soul_pos)

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -55,8 +55,6 @@ G.viewed_stake_act = {}
 G.viewed_stake_act[1] = 1
 G.viewed_stake_act[2] = 1
 
-AP_stakes_init = false
-
 -- true if the profile was selected and loaded
 function isAPProfileLoaded()
     return G.SETTINGS and G.AP and G.SETTINGS.profile == G.AP.profile_Id
@@ -775,7 +773,8 @@ function Game:init_item_prototypes()
 		for i = 1, 8, 1 do
 			G.PROFILES[G.AP.profile_Id].stake_unlocks[i] = false
 		end
-		G.PROFILES[G.AP.profile_Id].stake_unlocks[1] = true
+		-- G.PROFILES[G.AP.profile_Id].stake_unlocks[1] = true
+		-- ^ uncomment to force the first stake to be always open 
 	end
 	
         -- Handle Queued Bonus stuff
@@ -1061,8 +1060,6 @@ end
 local GUIDEFrun_setup_option = G.UIDEF.run_setup_option
 function G.UIDEF.run_setup_option(type)
 	if isAPProfileLoaded() then
-		-- initiate stake swap (i need stakes to exist to do it)
-		if AP_stakes_init == false then init_AP_stakes() end
 		
 		if not G.SAVED_GAME then
 			G.SAVED_GAME = get_compressed(G.SETTINGS.profile..'/'..'save.jkr')
@@ -1184,6 +1181,13 @@ G.FUNCS.change_stake = function(args)
 	else
 		return GFUNCSchange_stakeRef(args)
 	end
+end
+
+local game_splash_screenRef = Game.splash_screen
+function Game:splash_screen()
+-- initiate stake swap (i need stakes to exist to do it)
+	if isAPProfileLoaded() then init_AP_stakes() end
+	return game_splash_screenRef(self)
 end
 
 -- handle stakes (stuff that can be easily handled by patches)


### PR DESCRIPTION
- reinserts the stakes on boot to follow the provided `included_stakes` (including the order)
- Most of the stake-related UI changed to allow for non-linear progression
- Game logic updated to refer to stake LEVEL instead of stake ORDER
- Prepared profile data to support stake items that unlock stakes
- Prepared the achievement notification to support stakes (chips for global stakes and stickered backs for deck-specific stakes)
      - as a part of this, sprites with two layers (e.g. The Soul) now display correctly