### PR TITLE
recursive stake checks fixes, trap notifications, extra goals

### DIFF
--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -791,27 +791,33 @@ function APConnect()
                     if (item_id == 330) then
                         -- Lose All Money
                         ease_dollars(-G.GAME.dollars, true)
+                        notify_alert("t_money", "Trap")
 
                     elseif (item_id == 331) then
                         -- Lose 1 Discard
                         ease_discard(-1)
+                        notify_alert("t_discard", "Trap")
                     elseif item_id == 332 then
                         -- Lose 1 Hand
                         ease_hands_played(-1)
+                        notify_alert("t_hand", "Trap")
                     elseif item_id == 333 then
                         -- make joker perishable
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_perishable(true)
+                            notify_alert("t_perishable", "Trap")
                         end
                     elseif item_id == 334 then
                         -- make joker eternal
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_eternal(true)
+                            notify_alert("t_eternal", "Trap")
                         end
                     elseif item_id == 335 then
                         -- make joker rental
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_rental(true)
+                            notify_alert("t_rental", "Trap")
                         end
                     end
 

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -2565,7 +2565,11 @@ function sendLocationCleared(id)
 
         if (tableContains(G.APClient.missing_locations, id)) then
             G.FUNCS.resolve_location_id_to_name(id)
-            notify_alert(id, "location")
+	
+	    -- dont send out a location alert if sending item to yourself
+	    if G.AP.location_id_to_item_name[id].player_name ~= G.AP.APSlot then
+                notify_alert(id, "location")
+	    end
         end
         G.APClient:LocationChecks({id})
     end

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -1337,6 +1337,7 @@ function G.UIDEF.stake_option(_type)
             G.viewed_stake_act[1] = 1
             G.viewed_stake_act[2] = G.viewed_stake_act[2]
         else
+	    G.viewed_stake_act[2] = G.viewed_stake_act[2] or 1
             for i = 1, #stake_options, 1 do
                 if stake_options[i] <= G.viewed_stake_act[2] then
                     G.viewed_stake_act[1] = i

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -2422,8 +2422,8 @@ function create_UIBox_notify_alert(_achievement, _type)
 
         -- second layer for the soul, the hologramm and the legendaries
         if (_c and _c.soul_pos) or _achievement == 'c_soul' then
-            local _soul_atlas = _achievement == 'c_soul' and G.ASSET_ATLAS["centers"] or _type == 'BackStake' and
-                                    G.ASSET_ATLAS["stickers"] or G.ASSET_ATLAS["Joker"]
+            local _soul_atlas = _achievement == 'c_soul' and G.ASSET_ATLAS["centers"] or _type == 'Joker' and
+                                    G.ASSET_ATLAS["Joker"] or G.ASSET_ATLAS["stickers"]
             local _soul_pos = _achievement == 'c_soul' and {
                 x = 0,
                 y = 1

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -904,6 +904,7 @@ function Game:init_item_prototypes()
         self.P_CENTERS['b_red'] = self.P_CENTERS[standard_deck]
 
         init_AP_stakes()
+	G:save_progress()
     end
     return game_init_item_prototypes
 end

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -526,7 +526,7 @@ function Game:draw()
                         love.graphics.print("Goal: Beat Ante " .. G.AP.slot_data.ante_win_goal, 10, 60)
 
 			-- beat # decks on at least # stake
-		    elseif G.AP.goal == 3
+		    elseif G.AP.goal == 3 then
 			local _line = "Goal: Beat " .. G.AP.slot_data.decks_win_goal .. " Decks on at least "
 
 			if G.AP.StakesInit then
@@ -535,10 +535,10 @@ function Game:draw()
 				_line = _line .. "Stake " .. tostring(G.AP.slot_data.required_stake)
 			end
 			
-			_line = _line .. "difficulty. You already beat " .. tostring(G.PROFILES[G.AP.profile_Id].ap_progress) .. " Decks.
+			_line = _line .. "difficulty. You already beat " .. tostring(G.PROFILES[G.AP.profile_Id].ap_progress) .. " Decks."
 			love.graphics.print(_line, 10, 60)
 			-- win with # jokers on at least # stake
-		    elseif G.AP.goal == 4
+		    elseif G.AP.goal == 4 then
 			local _line = "Goal: Win with " .. G.AP.slot_data.jokers_unlock_goal .. " Jokers on at least "
 
 			if G.AP.StakesInit then
@@ -547,7 +547,7 @@ function Game:draw()
 				_line = _line .. "Stake " .. tostring(G.AP.slot_data.required_stake)
 			end
 			
-			_line = _line .. "difficulty. You have already won with " .. tostring(G.PROFILES[G.AP.profile_Id].ap_progress) .. " Jokers.
+			_line = _line .. "difficulty. You have already won with " .. tostring(G.PROFILES[G.AP.profile_Id].ap_progress) .. " Jokers."
 			love.graphics.print(_line, 10, 60)
                     end
                 end


### PR DESCRIPTION
- Fixed stack overflow related to recursive stake checks.
- Fixed "Also applies" window.
- Added Trap notifications.
     - Eternal, Perishable and Rental traps are rendered as a negative Joker with their respective sticker
     - Lose a hand/discard/all money are rendered as negative Grabber, Wasteful and Liquidation
- Added new goals.
     - Goal 3: Beat # Decks on at least # Stake difficulty.
     - Goal 4: Win with # Jokers on at least # Stake difficulty.