### PR TITLE
recursive stake check fix, trap notifications, new goal

### DIFF
--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -961,6 +961,80 @@ function APConnect()
                         end
                     end
 
+                elseif item_id >= 400 then
+                    local deck_name = ""
+                    local stake_name = ""
+                    if item_id <= 407 then
+                        deck_name = "b_red"
+                        on_items_received({{index = "reddeck", item = 1 + G.AP.id_offset}})
+                    elseif item_id <= 415 then
+                        deck_name = "b_blue"
+                        on_items_received({{index = "bluedeck", item = 2+ G.AP.id_offset}})
+                    elseif item_id <= 423 then
+                        deck_name = "b_yellow"
+                        on_items_received({{index = "yellowdeck", item = 3+ G.AP.id_offset}})
+                    elseif item_id <= 431 then
+                        deck_name = "b_green"
+                        on_items_received({{index = "greendeck", item = 4+ G.AP.id_offset}})
+                    elseif item_id <= 439 then
+                        deck_name = "b_black"
+                        on_items_received({{index = "blackdeck", item = 5+ G.AP.id_offset}})
+                    elseif item_id <= 447 then
+                        deck_name = "b_magic"
+                        on_items_received({{index = "magicdeck", item = 6+ G.AP.id_offset}})
+                    elseif item_id <= 455 then
+                        deck_name = "b_nebula"
+                        on_items_received({{index = "nebuladeck", item = 7+ G.AP.id_offset}})
+                    elseif item_id <= 463 then
+                        deck_name = "b_ghost"
+                        on_items_received({{index = "ghostdeck", item = 8+ G.AP.id_offset}})
+                    elseif item_id <= 471 then
+                        deck_name = "b_abandoned"
+                        on_items_received({{index = "abandoneddeck", item = 9+ G.AP.id_offset}})
+                    elseif item_id <= 479 then
+                        deck_name = "b_checkered"
+                        on_items_received({{index = "checkdeck", item = 10+ G.AP.id_offset}})
+                    elseif item_id <= 487 then
+                        deck_name = "b_zodiac"
+                        on_items_received({{index = "zodiacdeck", item = 11+ G.AP.id_offset}})
+                    elseif item_id <= 495 then
+                        deck_name = "b_painted"
+                        on_items_received({{index = "painteddeck", item = 12+ G.AP.id_offset}})
+                    elseif item_id <= 503 then
+                        deck_name = "b_anaglyph"
+                        on_items_received({{index = "anaglyphdeck", item = 13+ G.AP.id_offset}})
+                    elseif item_id <= 411 then
+                        deck_name = "b_plasma"
+                        on_items_received({{index = "plasmadeck", item = 14+ G.AP.id_offset}})
+                    elseif item_id <= 419 then
+                        deck_name = "b_erratic"
+                        on_items_received({{index = "erraticdeck", item = 15+ G.AP.id_offset}})
+                    end
+
+
+                    if item_id % 8 == 0 then
+                        stake_name = "stake_white"
+                    elseif (item_id - 1) % 8 == 0 then
+                        stake_name = "stake_red"
+                    elseif (item_id - 2) % 8 == 0 then
+                        stake_name = "stake_green"
+                    elseif (item_id - 3) % 8 == 0 then
+                        stake_name = "stake_black"
+                    elseif (item_id - 4) % 8 == 0 then
+                        stake_name = "stake_blue"
+                    elseif (item_id - 5) % 8 == 0 then
+                        stake_name = "stake_purple"
+                    elseif (item_id - 6) % 8 == 0 then
+                        stake_name = "stake_orange"
+                    elseif (item_id - 7) % 8 == 0 then
+                        stake_name = "stake_gold"
+                    end
+
+                    if (G.AP.StakesInit) then 
+                        G.FUNCS.AP_unlock_stake_per_deck(stake_name, deck_name)
+                    else
+                        G.AP.StakeQueue[#G.AP.StakeQueue + 1] = {stake = stake_name, deck = deck_name}
+                    end
                 end
 
             end

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -311,6 +311,7 @@ function APConnect()
     G.AP.BonusQueue = {}
     G.AP.PackQueue = {}
     G.AP.ConsumableQueue = {}
+    G.AP.StakeQueue = {}
 
     function on_socket_connected()
         print("Socket connected")
@@ -870,7 +871,98 @@ function APConnect()
                         end
                         on_items_received(items_to_unlock)
                     end
+                elseif item_id >= 390 and item_id <= 397 then
+                    if item_id == 390 then
+                        if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
+                            G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
+                            if (G.AP.StakesInit) then
+                                G.FUNCS.AP_unlock_stake('White Stake')
+                            else
+                                G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'White Stake'
+                            end
+
+                        end
+                    end
+                    if item_id == 391 then
+                        if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
+                            G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
+                            if (G.AP.StakesInit) then
+                                G.FUNCS.AP_unlock_stake('Red Stake')
+                            else
+                                G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Red Stake'
+                            end
+
+                        end
+                    end
+                    if item_id == 392 then
+                        if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
+                            G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
+                            if (G.AP.StakesInit) then
+                                G.FUNCS.AP_unlock_stake('Green Stake')
+                            else
+                                G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Green Stake'
+                            end
+
+                        end
+                    end
+                    if item_id == 393 then
+                        if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
+                            G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
+                            if (G.AP.StakesInit) then
+                                G.FUNCS.AP_unlock_stake('Black Stake')
+                            else
+                                G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Black Stake'
+                            end
+
+                        end
+                    end
+                    if item_id == 394 then
+                        if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
+                            G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
+                            if (G.AP.StakesInit) then
+                                G.FUNCS.AP_unlock_stake('Blue Stake')
+                            else
+                                G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Blue Stake'
+                            end
+
+                        end
+                    end
+                    if item_id == 395 then
+                        if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
+                            G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
+                            if (G.AP.StakesInit) then
+                                G.FUNCS.AP_unlock_stake('Purple Stake')
+                            else
+                                G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Purple Stake'
+                            end
+
+                        end
+                    end
+                    if item_id == 396 then
+                        if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
+                            G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
+                            if (G.AP.StakesInit) then
+                                G.FUNCS.AP_unlock_stake('Orange Stake')
+                            else
+                                G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Orange Stake'
+                            end
+
+                        end
+                    end
+                    if item_id == 397 then
+                        if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
+                            G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
+                            if (G.AP.StakesInit) then
+                                G.FUNCS.AP_unlock_stake('Gold Stake')
+                            else
+                                G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Gold Stake'
+                            end
+
+                        end
+                    end
+
                 end
+
             end
         end
 
@@ -882,20 +974,23 @@ function APConnect()
     function on_location_info(items)
         for _, item in ipairs(items) do
             if not G.AP.location_id_to_item_name[item.location] then
-                
+
                 local player = item.player
 
                 if not player_to_alias[player] then
                     player_to_alias[player] = G.APClient:get_player_alias(item.player)
                 end
-                
+
                 if not player_to_game[player] then
                     player_to_game[player] = G.APClient:get_player_game(item.player)
                 end
-                
+
                 local player_alias = player_to_alias[player]
                 local game = player_to_game[player]
-                G.AP.location_id_to_item_name[item.location] = {item_name = G.APClient:get_item_name(item.item, game), player_name = player_alias} 
+                G.AP.location_id_to_item_name[item.location] = {
+                    item_name = G.APClient:get_item_name(item.item, game),
+                    player_name = player_alias
+                }
 
             end
         end
@@ -903,7 +998,7 @@ function APConnect()
     end
 
     function on_location_checked(locations)
-        --print("Locations checked:" .. table.concat(locations, ", "))
+        -- print("Locations checked:" .. table.concat(locations, ", "))
     end
 
     function on_data_package_changed(data_package)

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -791,27 +791,33 @@ function APConnect()
                     if (item_id == 330) then
                         -- Lose All Money
                         ease_dollars(-G.GAME.dollars, true)
+                        notify_alert("t_money", "Trap")
 
                     elseif (item_id == 331) then
                         -- Lose 1 Discard
                         ease_discard(-1)
+                        notify_alert("t_discard", "Trap")
                     elseif item_id == 332 then
                         -- Lose 1 Hand
                         ease_hands_played(-1)
+                        notify_alert("t_hand", "Trap")
                     elseif item_id == 333 then
                         -- make joker perishable
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_perishable(true)
+                            notify_alert("t_perishable", "Trap")
                         end
                     elseif item_id == 334 then
                         -- make joker eternal
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_eternal(true)
+                            notify_alert("t_eternal", "Trap")
                         end
                     elseif item_id == 335 then
                         -- make joker rental
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_rental(true)
+                            notify_alert("t_rental", "Trap")
                         end
                     end
 

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -526,7 +526,7 @@ function Game:draw()
                         love.graphics.print("Goal: Beat Ante " .. G.AP.slot_data.ante_win_goal, 10, 60)
 
 			-- beat # decks on at least # stake
-		    elseif G.AP.goal == 3
+		    elseif G.AP.goal == 3 then
 			local _line = "Goal: Beat " .. G.AP.slot_data.decks_win_goal .. " Decks on at least "
 
 			if G.AP.StakesInit then
@@ -535,10 +535,10 @@ function Game:draw()
 				_line = _line .. "Stake " .. tostring(G.AP.slot_data.required_stake)
 			end
 			
-			_line = _line .. "difficulty. You already beat " .. tostring(G.PROFILES[G.AP.profile_Id].ap_progress) .. " Decks.
+			_line = _line .. "difficulty. You already beat " .. tostring(G.PROFILES[G.AP.profile_Id].ap_progress) .. " Decks."
 			love.graphics.print(_line, 10, 60)
 			-- win with # jokers on at least # stake
-		    elseif G.AP.goal == 4
+		    elseif G.AP.goal == 4 then
 			local _line = "Goal: Win with " .. G.AP.slot_data.jokers_unlock_goal .. " Jokers on at least "
 
 			if G.AP.StakesInit then
@@ -547,7 +547,7 @@ function Game:draw()
 				_line = _line .. "Stake " .. tostring(G.AP.slot_data.required_stake)
 			end
 			
-			_line = _line .. "difficulty. You have already won with " .. tostring(G.PROFILES[G.AP.profile_Id].ap_progress) .. " Jokers.
+			_line = _line .. "difficulty. You have already won with " .. tostring(G.PROFILES[G.AP.profile_Id].ap_progress) .. " Jokers."
 			love.graphics.print(_line, 10, 60)
                     end
                 end

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -51,7 +51,7 @@ G.AP.profile_Id = -1
 G.AP.GameObjectInit = false
 G.AP.StakesInit = false
 
---stake cursor used for AP logic
+-- stake cursor used for AP logic
 G.viewed_stake_act = {}
 G.viewed_stake_act[1] = 1
 G.viewed_stake_act[2] = 1
@@ -617,16 +617,21 @@ G.FUNCS.AP_unlock_stake = function(stake_name)
 end
 
 G.FUNCS.AP_unlock_stake_per_deck = function(stake_key, deck_key)
+    for k, v in ipairs(G.P_CENTER_POOLS.Stake) do
+        if stake_key == nil then
+            sendDebugMessage("stake_key is nil, this is bad!")
+        end
+        if (v.key == stake_key) then
 
-    sendDebugMessage("Unlocking " .. tostring(stake_key) .. " for deck " .. tostring(deck_key))
-    G.PROFILES[G.AP.profile_Id].deck_usage[deck_key].stake_unlocks[stake_key] = true
+            G.PROFILES[G.AP.profile_Id].deck_usage[deck_key].stake_unlocks[k] = true
 
-    if G.AP.StakesInit then
-        notify_alert(stake_key .. deck_key, 'BackStake')
+            if G.AP.StakesInit then
+                notify_alert(stake_key .. deck_key, 'BackStake')
+            end
+
+        end
     end
 
-
-   
 end
 
 local game_init_item_prototypesRef = Game.init_item_prototypes
@@ -725,18 +730,28 @@ function Game:init_item_prototypes()
                     standard_deck = k
                 end
 
-		-- create (or fix) deck_usage (for stake unlocks)
-		if not G.PROFILES[G.AP.profile_Id].deck_usage then G.PROFILES[G.AP.profile_Id].deck_usage = {} end
-		if not G.PROFILES[G.AP.profile_Id].deck_usage[k] then G.PROFILES[G.AP.profile_Id].deck_usage[k] = {} end
-		if not G.PROFILES[G.AP.profile_Id].deck_usage[k].count then G.PROFILES[G.AP.profile_Id].deck_usage[k].count = 0 end
-		if not G.PROFILES[G.AP.profile_Id].deck_usage[k].wins then G.PROFILES[G.AP.profile_Id].deck_usage[k].wins = {} end
-		if not G.PROFILES[G.AP.profile_Id].deck_usage[k].losses then G.PROFILES[G.AP.profile_Id].deck_usage[k].losses = {} end
-		if not G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks then
-			G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks = {}
-			for i = 1, 8, 1 do
-				G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks[i] = false
-			end
-		end
+                -- create (or fix) deck_usage (for stake unlocks)
+                if not G.PROFILES[G.AP.profile_Id].deck_usage then
+                    G.PROFILES[G.AP.profile_Id].deck_usage = {}
+                end
+                if not G.PROFILES[G.AP.profile_Id].deck_usage[k] then
+                    G.PROFILES[G.AP.profile_Id].deck_usage[k] = {}
+                end
+                if not G.PROFILES[G.AP.profile_Id].deck_usage[k].count then
+                    G.PROFILES[G.AP.profile_Id].deck_usage[k].count = 0
+                end
+                if not G.PROFILES[G.AP.profile_Id].deck_usage[k].wins then
+                    G.PROFILES[G.AP.profile_Id].deck_usage[k].wins = {}
+                end
+                if not G.PROFILES[G.AP.profile_Id].deck_usage[k].losses then
+                    G.PROFILES[G.AP.profile_Id].deck_usage[k].losses = {}
+                end
+                if not G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks then
+                    G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks = {}
+                    for i = 1, 8, 1 do
+                        G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks[i] = false
+                    end
+                end
 
                 -- for vouchers
             elseif string.find(k, '^v_') and not string.find(k, '^v_rand_ap_item') then
@@ -795,16 +810,16 @@ function Game:init_item_prototypes()
 
         end
 
-	-- Handle global stake unlock save data
-	if not G.PROFILES[G.AP.profile_Id].stake_unlocks then
-		G.PROFILES[G.AP.profile_Id].stake_unlocks = {}
-		for i = 1, 8, 1 do
-			G.PROFILES[G.AP.profile_Id].stake_unlocks[i] = false
-		end
-		-- G.PROFILES[G.AP.profile_Id].stake_unlocks[1] = true
-		-- ^ uncomment to force the first stake to be always open 
-	end
-	
+        -- Handle global stake unlock save data
+        if not G.PROFILES[G.AP.profile_Id].stake_unlocks then
+            G.PROFILES[G.AP.profile_Id].stake_unlocks = {}
+            for i = 1, 8, 1 do
+                G.PROFILES[G.AP.profile_Id].stake_unlocks[i] = false
+            end
+            -- G.PROFILES[G.AP.profile_Id].stake_unlocks[1] = true
+            -- ^ uncomment to force the first stake to be always open 
+        end
+
         -- Handle Queued Bonus stuff
 
         for k, v in pairs(G.AP.BonusQueue) do
@@ -859,126 +874,174 @@ end
 
 -- reinsert the stakes in the desired order, removing the modded ones
 function init_AP_stakes()
-	
-	local _defaul_stakes = {}
-	_defaul_stakes[1] = {
+
+    local _defaul_stakes = {}
+    _defaul_stakes[1] = {
         name = "White Stake",
         key = "stake_white",
-	original_key = "white",
+        original_key = "white",
         applied_stakes = {},
-		atlas = "chips",
-        pos = { x = 0, y = 0 },
-        sticker_pos = { x = 1, y = 0 },
+        atlas = "chips",
+        pos = {
+            x = 0,
+            y = 0
+        },
+        sticker_pos = {
+            x = 1,
+            y = 0
+        },
         colour = G.C.WHITE,
-	shiny = false,
+        shiny = false,
         loc_txt = {}
     }
-	
-	_defaul_stakes[2] = {
+
+    _defaul_stakes[2] = {
         name = "Red Stake",
         key = "stake_red",
-	original_key = "red",
-        applied_stakes = { "white" },
-	atlas = "chips",
-        pos = { x = 1, y = 0 },
-        sticker_pos = { x = 2, y = 0 },
+        original_key = "red",
+        applied_stakes = {"white"},
+        atlas = "chips",
+        pos = {
+            x = 1,
+            y = 0
+        },
+        sticker_pos = {
+            x = 2,
+            y = 0
+        },
         modifiers = function()
             G.GAME.modifiers.no_blind_reward = G.GAME.modifiers.no_blind_reward or {}
             G.GAME.modifiers.no_blind_reward.Small = true
         end,
         colour = G.C.RED,
-	shiny = false,
+        shiny = false,
         loc_txt = {}
     }
-	
-	_defaul_stakes[3] = {
+
+    _defaul_stakes[3] = {
         name = "Green Stake",
         key = "stake_green",
-	original_key = "green",
-        applied_stakes = { "red" },
-	atlas = "chips",
-        pos = { x = 2, y = 0 },
-        sticker_pos = { x = 3, y = 0 },
+        original_key = "green",
+        applied_stakes = {"red"},
+        atlas = "chips",
+        pos = {
+            x = 2,
+            y = 0
+        },
+        sticker_pos = {
+            x = 3,
+            y = 0
+        },
         modifiers = function()
             G.GAME.modifiers.scaling = math.max(G.GAME.modifiers.scaling or 0, 2)
         end,
         colour = G.C.GREEN,
-	shiny = false,
+        shiny = false,
         loc_txt = {}
     }
-	
-	_defaul_stakes[4] = {
+
+    _defaul_stakes[4] = {
         name = "Black Stake",
         key = "stake_black",
-	original_key = "black",
-        applied_stakes = { "green" },
-	atlas = "chips",
-        pos = { x = 4, y = 0 },
-        sticker_pos = { x = 0, y = 1 },
+        original_key = "black",
+        applied_stakes = {"green"},
+        atlas = "chips",
+        pos = {
+            x = 4,
+            y = 0
+        },
+        sticker_pos = {
+            x = 0,
+            y = 1
+        },
         modifiers = function()
             G.GAME.modifiers.enable_eternals_in_shop = true
         end,
         colour = G.C.BLACK,
-	shiny = false,
+        shiny = false,
         loc_txt = {}
     }
-	
-	_defaul_stakes[5] = {
+
+    _defaul_stakes[5] = {
         name = "Blue Stake",
-	key = "stake_blue",
+        key = "stake_blue",
         original_key = "blue",
-        applied_stakes = { "black" },
-	atlas = "chips",
-        pos = { x = 3, y = 0 },
-        sticker_pos = { x = 4, y = 0 },
+        applied_stakes = {"black"},
+        atlas = "chips",
+        pos = {
+            x = 3,
+            y = 0
+        },
+        sticker_pos = {
+            x = 4,
+            y = 0
+        },
         modifiers = function()
             G.GAME.starting_params.discards = G.GAME.starting_params.discards - 1
         end,
         colour = G.C.BLUE,
-		shiny = false,
+        shiny = false,
         loc_txt = {}
     }
-	
-	_defaul_stakes[6] = {
+
+    _defaul_stakes[6] = {
         name = "Purple Stake",
-	key = "stake_purple",
+        key = "stake_purple",
         original_key = "purple",
-        applied_stakes = { "blue" },
-	atlas = "chips",
-        pos = { x = 0, y = 1 },
-        sticker_pos = { x = 1, y = 1 },
+        applied_stakes = {"blue"},
+        atlas = "chips",
+        pos = {
+            x = 0,
+            y = 1
+        },
+        sticker_pos = {
+            x = 1,
+            y = 1
+        },
         modifiers = function()
             G.GAME.modifiers.scaling = math.max(G.GAME.modifiers.scaling or 0, 3)
         end,
         colour = G.C.PURPLE,
-	shiny = false,
+        shiny = false,
         loc_txt = {}
     }
-	
-	_defaul_stakes[7] = {
+
+    _defaul_stakes[7] = {
         name = "Orange Stake",
         key = "stake_orange",
-	original_key = "orange",
-        applied_stakes = { "purple" },
-	atlas = "chips",
-        pos = { x = 1, y = 1 },
-        sticker_pos = { x = 2, y = 1 },
+        original_key = "orange",
+        applied_stakes = {"purple"},
+        atlas = "chips",
+        pos = {
+            x = 1,
+            y = 1
+        },
+        sticker_pos = {
+            x = 2,
+            y = 1
+        },
         modifiers = function()
             G.GAME.modifiers.enable_perishables_in_shop = true
         end,
         colour = G.C.ORANGE,
-	shiny = false,
+        shiny = false,
         loc_txt = {}
     }
-	
-	_defaul_stakes[8] = {
+
+    _defaul_stakes[8] = {
         name = "Gold Stake",
-	key = "stake_gold",
+        key = "stake_gold",
         original_key = "gold",
-        applied_stakes = { "orange" },
-	atlas = "chips",
-        pos = { x = 2, y = 1 },
-        sticker_pos = { x = 3, y = 1 },
+        applied_stakes = {"orange"},
+        atlas = "chips",
+        pos = {
+            x = 2,
+            y = 1
+        },
+        sticker_pos = {
+            x = 3,
+            y = 1
+        },
         modifiers = function()
             G.GAME.modifiers.enable_rentals_in_shop = true
         end,
@@ -986,56 +1049,56 @@ function init_AP_stakes()
         shiny = true,
         loc_txt = {}
     }
-	
-	-- create a copy of included stake list
-	local _stake_list = {}
-	for i = 1, #G.AP.slot_data.included_stakes, 1 do
-		_stake_list[i] = G.AP.slot_data.included_stakes[i]
-	end
-	
-	-- insert unused stakes at the end of the list
-	-- (we must have all 8 stakes existing, otherwise
-	-- the game crashes when trying to apply a nonexistent stake)
-	--      (^ could be solved by rerouting the applied stakes)
-	--      (but that changes the difficulties of the stakes)
-	for i = 1, 8, 1 do
-		if not tableContains(_stake_list, i) then
-			_stake_list[#_stake_list+1] = i
-		end
-	end
 
+    -- create a copy of included stake list
+    local _stake_list = {}
+    for i = 1, #G.AP.slot_data.included_stakes, 1 do
+        _stake_list[i] = G.AP.slot_data.included_stakes[i]
+    end
 
-	for i = 1, 8, 1 do
-		-- just copy these values
-		G.P_CENTER_POOLS.Stake[i].name = _defaul_stakes[_stake_list[i]].name
-		G.P_CENTER_POOLS.Stake[i].key = _defaul_stakes[_stake_list[i]].key
-		G.P_CENTER_POOLS.Stake[i].original_key = _defaul_stakes[_stake_list[i]].original_key
-		G.P_CENTER_POOLS.Stake[i].applied_stakes = _defaul_stakes[_stake_list[i]].applied_stakes
-		G.P_CENTER_POOLS.Stake[i].atlas = _defaul_stakes[_stake_list[i]].atlas
-		G.P_CENTER_POOLS.Stake[i].pos = _defaul_stakes[_stake_list[i]].pos
-		G.P_CENTER_POOLS.Stake[i].sticker_pos = _defaul_stakes[_stake_list[i]].sticker_pos
-		G.P_CENTER_POOLS.Stake[i].modifiers = _defaul_stakes[_stake_list[i]].modifiers
-		G.P_CENTER_POOLS.Stake[i].colour = _defaul_stakes[_stake_list[i]].colour
-		G.P_CENTER_POOLS.Stake[i].shiny = _defaul_stakes[_stake_list[i]].shiny
-		G.P_CENTER_POOLS.Stake[i].loc_txt = _defaul_stakes[_stake_list[i]].loc_txt
-		G.P_CENTER_POOLS.Stake[i].stake_level = _stake_list[i]
-		
-		-- read global unlock from the profile
-		G.P_CENTER_POOLS.Stake[i].unlocked = G.PROFILES[G.AP.profile_Id].stake_unlocks[i]
-		
-		-- set the unlocked stake data if not last in/outside of included list
-		G.P_CENTER_POOLS.Stake[i].unlocked_stake = i < #G.AP.slot_data.included_stakes and _defaul_stakes[_stake_list[i+1]].original_key or nil
-	end
-	
-	--remove excess stakes generated by other mods
-	while #G.P_CENTER_POOLS.Stake > 8 do
-		table.remove(G.P_CENTER_POOLS.Stake, #G.P_CENTER_POOLS.Stake)
-	end
-	
-	--update the colors
-	for i = 1, #G.P_CENTER_POOLS.Stake do
-		G.C.STAKES[i] = G.P_CENTER_POOLS.Stake[i].colour or G.C.WHITE
-	end
+    -- insert unused stakes at the end of the list
+    -- (we must have all 8 stakes existing, otherwise
+    -- the game crashes when trying to apply a nonexistent stake)
+    --      (^ could be solved by rerouting the applied stakes)
+    --      (but that changes the difficulties of the stakes)
+    for i = 1, 8, 1 do
+        if not tableContains(_stake_list, i) then
+            _stake_list[#_stake_list + 1] = i
+        end
+    end
+
+    for i = 1, 8, 1 do
+        -- just copy these values
+        G.P_CENTER_POOLS.Stake[i].name = _defaul_stakes[_stake_list[i]].name
+        G.P_CENTER_POOLS.Stake[i].key = _defaul_stakes[_stake_list[i]].key
+        G.P_CENTER_POOLS.Stake[i].original_key = _defaul_stakes[_stake_list[i]].original_key
+        G.P_CENTER_POOLS.Stake[i].applied_stakes = _defaul_stakes[_stake_list[i]].applied_stakes
+        G.P_CENTER_POOLS.Stake[i].atlas = _defaul_stakes[_stake_list[i]].atlas
+        G.P_CENTER_POOLS.Stake[i].pos = _defaul_stakes[_stake_list[i]].pos
+        G.P_CENTER_POOLS.Stake[i].sticker_pos = _defaul_stakes[_stake_list[i]].sticker_pos
+        G.P_CENTER_POOLS.Stake[i].modifiers = _defaul_stakes[_stake_list[i]].modifiers
+        G.P_CENTER_POOLS.Stake[i].colour = _defaul_stakes[_stake_list[i]].colour
+        G.P_CENTER_POOLS.Stake[i].shiny = _defaul_stakes[_stake_list[i]].shiny
+        G.P_CENTER_POOLS.Stake[i].loc_txt = _defaul_stakes[_stake_list[i]].loc_txt
+        G.P_CENTER_POOLS.Stake[i].stake_level = _stake_list[i]
+
+        -- read global unlock from the profile
+        G.P_CENTER_POOLS.Stake[i].unlocked = G.PROFILES[G.AP.profile_Id].stake_unlocks[i]
+
+        -- set the unlocked stake data if not last in/outside of included list
+        G.P_CENTER_POOLS.Stake[i].unlocked_stake = i < #G.AP.slot_data.included_stakes and
+                                                       _defaul_stakes[_stake_list[i + 1]].original_key or nil
+    end
+
+    -- remove excess stakes generated by other mods
+    while #G.P_CENTER_POOLS.Stake > 8 do
+        table.remove(G.P_CENTER_POOLS.Stake, #G.P_CENTER_POOLS.Stake)
+    end
+
+    -- update the colors
+    for i = 1, #G.P_CENTER_POOLS.Stake do
+        G.C.STAKES[i] = G.P_CENTER_POOLS.Stake[i].colour or G.C.WHITE
+    end
 
     -- empty queue
     for i = 1, #G.AP.StakeQueue do
@@ -1043,107 +1106,159 @@ function init_AP_stakes()
             G.FUNCS.AP_unlock_stake_per_deck(G.AP.StakeQueue[i].stake, G.AP.StakeQueue[i].deck)
         elseif type(G.AP.StakeQueue[i]) == "string" then
             G.FUNCS.AP_unlock_stake(G.AP.StakeQueue[i])
-        end    
-	end
+        end
+    end
 
     G.AP.StakeQueue = {}
     G.AP.StakesInit = true
 end
 
 function check_stake_unlock(_stake, _deck_key)
-	-- [Mode 0] all unlocked mode
-	if tonumber(G.AP.slot_data.stake_unlock_mode) == tonumber(0) then return true end
-	
-	-- [Mode 1] linear progression (vanilla)
-	-- (beating a stake unlocks the next one in the list)
-	-- (per deck)
-	if tonumber(G.AP.slot_data.stake_unlock_mode) == tonumber(1) then
-		if G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key] then
-			local _stake_progress = 0
-			for k, v in pairs(G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key].wins) do
-				_stake_progress = math.max(_stake_progress, k)
-			end
-			
-			if _stake <= _stake_progress+1 then return true end 
-		elseif _stake == 1 then return true end
-		
-		return false
-	end
-	
-	-- [Mode 2] global unlocks
-	-- (stakes are unlocked if their .unlocked exists and is true)
-	-- intended for making stakes into items
-	if tonumber(G.AP.slot_data.stake_unlock_mode) == tonumber(2) then
-		if G.P_CENTER_POOLS.Stake[_stake].unlocked then 
-		return G.P_CENTER_POOLS.Stake[_stake].unlocked end
-		
-		return false
-	end
-	
-	-- [Mode 3] individual unlocks
-	-- (stakes are unlocked if their entry in deck_usage.stake_unlocks exists and is true)
-	-- intended for making each deck's stakes into items
-	
-	-- (if used, the decks should be removed from the pool and be unlocked when
-	-- the player receives a stake for that deck)
-	if tonumber(G.AP.slot_data.stake_unlock_mode) == tonumber(3) then
-		if G.PROFILES[G.SETTINGS.profile].deck_usage and G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key] and
-		G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key].stake_unlocks then
-			return G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key].stake_unlocks[_stake] or false
-		end
-		
-	end
-	
-	return false
+    -- [Mode 0] all unlocked mode
+    if tonumber(G.AP.slot_data.stake_unlock_mode) == tonumber(0) then
+        return true
+    end
+
+    -- [Mode 1] linear progression (vanilla)
+    -- (beating a stake unlocks the next one in the list)
+    -- (per deck)
+    if tonumber(G.AP.slot_data.stake_unlock_mode) == tonumber(1) then
+        if G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key] then
+            local _stake_progress = 0
+            for k, v in pairs(G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key].wins) do
+                _stake_progress = math.max(_stake_progress, k)
+            end
+
+            if _stake <= _stake_progress + 1 then
+                return true
+            end
+        elseif _stake == 1 then
+            return true
+        end
+
+        return false
+    end
+
+    -- [Mode 2] global unlocks
+    -- (stakes are unlocked if their .unlocked exists and is true)
+    -- intended for making stakes into items
+    if tonumber(G.AP.slot_data.stake_unlock_mode) == tonumber(2) then
+        if G.P_CENTER_POOLS.Stake[_stake].unlocked then
+            return G.P_CENTER_POOLS.Stake[_stake].unlocked
+        end
+
+        return false
+    end
+
+    -- [Mode 3] individual unlocks
+    -- (stakes are unlocked if their entry in deck_usage.stake_unlocks exists and is true)
+    -- intended for making each deck's stakes into items
+
+    -- (if used, the decks should be removed from the pool and be unlocked when
+    -- the player receives a stake for that deck)
+    if tonumber(G.AP.slot_data.stake_unlock_mode) == tonumber(3) then
+        if G.PROFILES[G.SETTINGS.profile].deck_usage and G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key] and
+            G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key].stake_unlocks then
+            return G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key].stake_unlocks[_stake] or false
+        end
+
+    end
+
+    return false
 end
 
 local GUIDEFrun_setup_option = G.UIDEF.run_setup_option
 function G.UIDEF.run_setup_option(type)
-	if isAPProfileLoaded() then
-		
-		if not G.SAVED_GAME then
-			G.SAVED_GAME = get_compressed(G.SETTINGS.profile..'/'..'save.jkr')
-			if G.SAVED_GAME ~= nil then G.SAVED_GAME = STR_UNPACK(G.SAVED_GAME) end
-		end
+    if isAPProfileLoaded() then
 
-		-- fix AP stake cursor when viewing the continue screen
-		if G.SAVED_GAME ~= nil then
-			saved_game = G.SAVED_GAME
-			G.viewed_stake = saved_game.GAME.stake or 1
-			G.viewed_stake_act[2] = saved_game.GAME.stake or 1
-			G.viewed_stake_act[1] = 0
-		end
-	end
-	return GUIDEFrun_setup_option(type)
+        if not G.SAVED_GAME then
+            G.SAVED_GAME = get_compressed(G.SETTINGS.profile .. '/' .. 'save.jkr')
+            if G.SAVED_GAME ~= nil then
+                G.SAVED_GAME = STR_UNPACK(G.SAVED_GAME)
+            end
+        end
+
+        -- fix AP stake cursor when viewing the continue screen
+        if G.SAVED_GAME ~= nil then
+            saved_game = G.SAVED_GAME
+            G.viewed_stake = saved_game.GAME.stake or 1
+            G.viewed_stake_act[2] = saved_game.GAME.stake or 1
+            G.viewed_stake_act[1] = 0
+        end
+    end
+    return GUIDEFrun_setup_option(type)
 end
-
 
 local UIDEF_deck_stake_columnRef = G.UIDEF.deck_stake_column
 function G.UIDEF.deck_stake_column(_deck_key)
-    --hijack to use custom logic in AP
+    -- hijack to use custom logic in AP
     if isAPProfileLoaded() then
         local deck_usage = G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key]
-		local stake_col = {}
-		local valid_option = nil
-		local num_stakes = 0
-		
-		for i = #G.AP.slot_data.included_stakes, 1, -1 do
-			if check_stake_unlock(i, _deck_key) == true then
-				num_stakes = #G.AP.slot_data.included_stakes
-				break
-			end
-		end
-		
-		for i = num_stakes, 1, -1 do
-			valid_option = false
-			local _wins = deck_usage and deck_usage.wins[i] or 0
-			if check_stake_unlock(i, _deck_key) == true then valid_option = true end
-			
-			stake_col[#stake_col + 1] = {n = G.UIT.R, config = {id = i, align = "cm", colour = _wins > 0 and G.C.GREY or G.C.CLEAR, outline = 0, outline_colour = G.C.WHITE, r = 0.1, minh = 2 / 8, minw = valid_option and 0.45 or 0.25, func = 'RUN_SETUP_check_back_stake_highlight'}, nodes = {
-				{n = G.UIT.R, config = {align = "cm", minh = valid_option and 1.36 / 8 or 1.04 / 8, minw = valid_option and 0.37 or 0.13, colour = _wins > 0 and get_stake_col(i) or G.C.UI.TRANSPARENT_LIGHT, r = 0.1}, nodes = {}}}}
-			if i > 1 then stake_col[#stake_col + 1] = {n = G.UIT.R, config = {align = "cm", minh = 0.8 / 8, minw = 0.04 }, nodes = {} } end
-		end
-		return {n = G.UIT.ROOT, config = {align = 'cm', colour = G.C.CLEAR}, nodes = stake_col}
+        local stake_col = {}
+        local valid_option = nil
+        local num_stakes = 0
+
+        for i = #G.AP.slot_data.included_stakes, 1, -1 do
+        	if check_stake_unlock(i, _deck_key) == true then
+        		num_stakes = #G.AP.slot_data.included_stakes
+        		break
+        	end
+        end
+
+        -- num_stakes = #G.AP.slot_data.included_stakes
+
+        for i = num_stakes, 1, -1 do
+            valid_option = false
+            local _wins = deck_usage and deck_usage.wins[i] or 0
+            if check_stake_unlock(i, _deck_key) == true then
+                valid_option = true
+            end
+
+            stake_col[#stake_col + 1] = {
+                n = G.UIT.R,
+                config = {
+                    id = i,
+                    align = "cm",
+                    colour = _wins > 0 and G.C.GREY or G.C.CLEAR,
+                    outline = 0,
+                    outline_colour = G.C.WHITE,
+                    r = 0.1,
+                    minh = 2 / 8,
+                    minw = valid_option and 0.45 or 0.25,
+                    func = 'RUN_SETUP_check_back_stake_highlight'
+                },
+                nodes = {{
+                    n = G.UIT.R,
+                    config = {
+                        align = "cm",
+                        minh = valid_option and 1.36 / 8 or 1.04 / 8,
+                        minw = valid_option and 0.37 or 0.13,
+                        colour = _wins > 0 and get_stake_col(i) or G.C.UI.TRANSPARENT_LIGHT,
+                        r = 0.1
+                    },
+                    nodes = {}
+                }}
+            }
+            if i > 1 then
+                stake_col[#stake_col + 1] = {
+                    n = G.UIT.R,
+                    config = {
+                        align = "cm",
+                        minh = 0.8 / 8,
+                        minw = 0.04
+                    },
+                    nodes = {}
+                }
+            end
+        end
+        return {
+            n = G.UIT.ROOT,
+            config = {
+                align = 'cm',
+                colour = G.C.CLEAR
+            },
+            nodes = stake_col
+        }
     else
         return UIDEF_deck_stake_columnRef(_deck_key)
     end
@@ -1151,104 +1266,171 @@ end
 
 local stake_optionRef = G.UIDEF.stake_option
 function G.UIDEF.stake_option(_type)
-	--hijack the logic when AP is loaded
-	if isAPProfileLoaded() then
-		local middle = {n=G.UIT.R, config={align = "cm", minh = 1.7, minw = 7.3}, nodes={
-		{n=G.UIT.O, config={id = nil, func = 'RUN_SETUP_check_stake2', object = Moveable()}},}}
-		
-		local stake_options = {}
-		-- add unlocked stakes as options
-		for i = 1, #G.AP.slot_data.included_stakes, 1 do
-			if check_stake_unlock(i, G.GAME.viewed_back.effect.center.key) == true then
-				stake_options[#stake_options+1] = i
-			end
-		end
-	
-		-- when everything is locked, force the cursor into the bottom slot
-		if #stake_options == 0 then
-			G.viewed_stake = 1
-			G.viewed_stake_act[1] = 1
-			G.viewed_stake_act[2] = G.viewed_stake_act[2]
-		else
-			for i = 1, #stake_options, 1 do
-				if stake_options[i] <= G.viewed_stake_act[2] then
-					G.viewed_stake_act[1] = i
-				end
-			end
-			G.viewed_stake = stake_options[G.viewed_stake_act[1]]
-			G.viewed_stake_act[2] = stake_options[G.viewed_stake_act[1]]
-		end
-	  
-		return  {n=G.UIT.ROOT, config={align = "tm", colour = G.C.CLEAR, minh = 2.03, minw = 8.3}, nodes={_type == 'Continue' and middle or create_option_cycle({options = stake_options,
-		opt_callback = 'change_stake', current_option = G.viewed_stake_act[1], colour = G.C.RED, w = 6, mid = middle})}}
-	else
-        return stake_optionRef(_type)
-	end
-end
+    -- hijack the logic when AP is loaded
+    if isAPProfileLoaded() then
+        local middle = {
+            n = G.UIT.R,
+            config = {
+                align = "cm",
+                minh = 1.7,
+                minw = 7.3
+            },
+            nodes = {{
+                n = G.UIT.O,
+                config = {
+                    id = nil,
+                    func = 'RUN_SETUP_check_stake2',
+                    object = Moveable()
+                }
+            }}
+        }
 
+        local stake_options = {}
+        -- add unlocked stakes as options
+        for i = 1, #G.AP.slot_data.included_stakes, 1 do
+            if check_stake_unlock(i, G.GAME.viewed_back.effect.center.key) == true then
+                stake_options[#stake_options + 1] = i
+            end
+        end
+
+        -- when everything is locked, force the cursor into the bottom slot
+        if #stake_options == 0 then
+            G.viewed_stake = 1
+            G.viewed_stake_act[1] = 1
+            G.viewed_stake_act[2] = G.viewed_stake_act[2]
+        else
+            for i = 1, #stake_options, 1 do
+                if stake_options[i] <= G.viewed_stake_act[2] then
+                    G.viewed_stake_act[1] = i
+                end
+            end
+            G.viewed_stake = stake_options[G.viewed_stake_act[1]]
+            G.viewed_stake_act[2] = stake_options[G.viewed_stake_act[1]]
+        end
+
+        return {
+            n = G.UIT.ROOT,
+            config = {
+                align = "tm",
+                colour = G.C.CLEAR,
+                minh = 2.03,
+                minw = 8.3
+            },
+            nodes = {_type == 'Continue' and middle or create_option_cycle({
+                options = stake_options,
+                opt_callback = 'change_stake',
+                current_option = G.viewed_stake_act[1],
+                colour = G.C.RED,
+                w = 6,
+                mid = middle
+            })}
+        }
+    else
+        return stake_optionRef(_type)
+    end
+end
 
 local GUIDEFviewed_stake_optionRef = G.UIDEF.viewed_stake_option
 function G.UIDEF.viewed_stake_option()
-	if isAPProfileLoaded() then
-		G.viewed_stake = G.viewed_stake or 1
-		G.viewed_stake_act[1] = G.viewed_stake_act[1] or 1
-		G.viewed_stake_act[2] = G.viewed_stake_act[2] or 1
-		
-		if _type ~= 'Continue' then G.PROFILES[G.SETTINGS.profile].MEMORY.stake = G.viewed_stake end
+    if isAPProfileLoaded() then
+        G.viewed_stake = G.viewed_stake or 1
+        G.viewed_stake_act[1] = G.viewed_stake_act[1] or 1
+        G.viewed_stake_act[2] = G.viewed_stake_act[2] or 1
 
-		local stake_sprite = get_stake_sprite(G.viewed_stake)
+        if _type ~= 'Continue' then
+            G.PROFILES[G.SETTINGS.profile].MEMORY.stake = G.viewed_stake
+        end
 
-		return  {n=G.UIT.ROOT, config={align = "cm", colour = G.C.BLACK, r = 0.1}, nodes={
-			{n=G.UIT.C, config={align = "cm", padding = 0}, nodes={
-			  {n=G.UIT.T, config={text = localize('k_stake'), scale = 0.4, colour = G.C.L_BLACK, vert = true}}
-			}},
-			{n=G.UIT.C, config={align = "cm", padding = 0.1}, nodes={
-			  {n=G.UIT.C, config={align = "cm", padding = 0}, nodes={
-				{n=G.UIT.O, config={colour = G.C.BLUE, object = stake_sprite, hover = true, can_collide = false}},
-			  }},
-			  G.UIDEF.stake_description(G.viewed_stake)
-			}}
-		  }}
-	else
-		return GUIDEFviewed_stake_optionRef()
-	end
+        local stake_sprite = get_stake_sprite(G.viewed_stake)
+
+        return {
+            n = G.UIT.ROOT,
+            config = {
+                align = "cm",
+                colour = G.C.BLACK,
+                r = 0.1
+            },
+            nodes = {{
+                n = G.UIT.C,
+                config = {
+                    align = "cm",
+                    padding = 0
+                },
+                nodes = {{
+                    n = G.UIT.T,
+                    config = {
+                        text = localize('k_stake'),
+                        scale = 0.4,
+                        colour = G.C.L_BLACK,
+                        vert = true
+                    }
+                }}
+            }, {
+                n = G.UIT.C,
+                config = {
+                    align = "cm",
+                    padding = 0.1
+                },
+                nodes = {{
+                    n = G.UIT.C,
+                    config = {
+                        align = "cm",
+                        padding = 0
+                    },
+                    nodes = {{
+                        n = G.UIT.O,
+                        config = {
+                            colour = G.C.BLUE,
+                            object = stake_sprite,
+                            hover = true,
+                            can_collide = false
+                        }
+                    }}
+                }, G.UIDEF.stake_description(G.viewed_stake)}
+            }}
+        }
+    else
+        return GUIDEFviewed_stake_optionRef()
+    end
 end
 
 -- cursor logic
 local GFUNCSchange_stakeRef = G.FUNCS.change_stake
 G.FUNCS.change_stake = function(args)
-	if isAPProfileLoaded() then
-		local valid_stakes = {}
-		for i = 1, #G.AP.slot_data.included_stakes, 1 do
-			if check_stake_unlock(i, G.GAME.viewed_back.effect.center.key) == true then valid_stakes[#valid_stakes+1] = i end
-		end
-		
-		if args.cycle_config then
-			G.viewed_stake_act[1] = args.to_key
-			G.viewed_stake_act[2] = valid_stakes[G.viewed_stake_act[1]]
-		else
-			for k,v in pairs(valid_stakes) do
-				if v == args.to_key then
-					G.viewed_stake_act[1] = k
-					G.viewed_stake_act[2] = valid_stakes[G.viewed_stake_act[1]]
-					break
-				end
-			end
-		end
-	
-		if #valid_stakes == 0 then
-			G.viewed_stake = 1
-			G.viewed_stake_act[1] = 1
-			G.viewed_stake_act[2] = 1
-			G.PROFILES[G.SETTINGS.profile].MEMORY.stake = 1
-		else
-			G.viewed_stake = valid_stakes[G.viewed_stake_act[1]]
-			G.PROFILES[G.SETTINGS.profile].MEMORY.stake = G.viewed_stake
-			G.viewed_stake_act[2] = valid_stakes[G.viewed_stake_act[1]]
-		end
-	else
-		return GFUNCSchange_stakeRef(args)
-	end
+    if isAPProfileLoaded() then
+        local valid_stakes = {}
+        for i = 1, #G.AP.slot_data.included_stakes, 1 do
+            if check_stake_unlock(i, G.GAME.viewed_back.effect.center.key) == true then
+                valid_stakes[#valid_stakes + 1] = i
+            end
+        end
+
+        if args.cycle_config then
+            G.viewed_stake_act[1] = args.to_key
+            G.viewed_stake_act[2] = valid_stakes[G.viewed_stake_act[1]]
+        else
+            for k, v in pairs(valid_stakes) do
+                if v == args.to_key then
+                    G.viewed_stake_act[1] = k
+                    G.viewed_stake_act[2] = valid_stakes[G.viewed_stake_act[1]]
+                    break
+                end
+            end
+        end
+
+        if #valid_stakes == 0 then
+            G.viewed_stake = 1
+            G.viewed_stake_act[1] = 1
+            G.viewed_stake_act[2] = 1
+            G.PROFILES[G.SETTINGS.profile].MEMORY.stake = 1
+        else
+            G.viewed_stake = valid_stakes[G.viewed_stake_act[1]]
+            G.PROFILES[G.SETTINGS.profile].MEMORY.stake = G.viewed_stake
+            G.viewed_stake_act[2] = valid_stakes[G.viewed_stake_act[1]]
+        end
+    else
+        return GFUNCSchange_stakeRef(args)
+    end
 end
 
 -- local game_splash_screenRef = Game.splash_screen
@@ -1259,104 +1441,123 @@ end
 -- end
 
 -- handle stakes (stuff that can be easily handled by patches)
---white highlight on stake selection
+-- white highlight on stake selection
 local GFUNCSRUN_SETUP_check_back_stake_highlightRef = G.FUNCS.RUN_SETUP_check_back_stake_highlight
-G.FUNCS.RUN_SETUP_check_back_stake_highlight= function(e) 
-	if isAPProfileLoaded() then
-		if G.viewed_stake_act[2] == e.config.id and e.config.outline < 0.1 then 
-			e.config.outline = check_stake_unlock(G.viewed_stake_act[2], G.GAME.viewed_back.effect.center.key) == true and 0.8 or 0
-		elseif G.viewed_stake_act[2] ~= e.config.id and e.config.outline > 0.1 then
-			e.config.outline = 0
-		end
-	else
-		return GFUNCSRUN_SETUP_check_back_stake_highlightRef(e)
-	end
+G.FUNCS.RUN_SETUP_check_back_stake_highlight = function(e)
+    if isAPProfileLoaded() then
+        if G.viewed_stake_act[2] == e.config.id and e.config.outline < 0.1 then
+            e.config.outline =
+                check_stake_unlock(G.viewed_stake_act[2], G.GAME.viewed_back.effect.center.key) == true and 0.8 or 0
+        elseif G.viewed_stake_act[2] ~= e.config.id and e.config.outline > 0.1 then
+            e.config.outline = 0
+        end
+    else
+        return GFUNCSRUN_SETUP_check_back_stake_highlightRef(e)
+    end
 end
 
---deck win stickers (check stake level instead of slot)
+-- deck win stickers (check stake level instead of slot)
 local get_deck_win_stickerRef = get_deck_win_sticker
 function get_deck_win_sticker(_center)
-	if isAPProfileLoaded() then
-		if G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key] and G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key].wins then 
-			local _w = -1
-			for k, v in pairs(G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key].wins) do
-				if v > 0 then
-					_w = math.max(G.P_CENTER_POOLS.Stake[k].stake_level, _w)
-				end
-	   		end
-	   		if _w > 0 then return G.sticker_map[_w] end
-		end
-	else
-		return get_deck_win_stickerRef(_center)
-	end
+    if isAPProfileLoaded() then
+        if G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key] and
+            G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key].wins then
+            local _w = -1
+            for k, v in pairs(G.PROFILES[G.SETTINGS.profile].deck_usage[_center.key].wins) do
+                if v > 0 then
+                    _w = math.max(G.P_CENTER_POOLS.Stake[k].stake_level, _w)
+                end
+            end
+            if _w > 0 then
+                return G.sticker_map[_w]
+            end
+        end
+    else
+        return get_deck_win_stickerRef(_center)
+    end
 end
 
 -- joker win stickers (check stake level instead of slot)
 local get_joker_win_stickerRef = get_joker_win_sticker
 function get_joker_win_sticker(_center, index)
-	if isAPProfileLoaded() then
-		if G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key] and G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key].wins then 
-			local _w = 0
-			for k, v in pairs(G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key].wins) do
-				_w = math.max(G.P_CENTER_POOLS.Stake[k].stake_level, _w)
-			end
-			if index then return _w end
-			if _w > 0 then return G.sticker_map[_w] end
-		end
-		if index then return 0 end
-	else
-		return get_joker_win_stickerRef(_center, index)
-	end
+    if isAPProfileLoaded() then
+        if G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key] and
+            G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key].wins then
+            local _w = 0
+            for k, v in pairs(G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key].wins) do
+                _w = math.max(G.P_CENTER_POOLS.Stake[k].stake_level, _w)
+            end
+            if index then
+                return _w
+            end
+            if _w > 0 then
+                return G.sticker_map[_w]
+            end
+        end
+        if index then
+            return 0
+        end
+    else
+        return get_joker_win_stickerRef(_center, index)
+    end
 end
 
 -- set deck win (prevent higher stake wins from counting as a win for previous stakes)
 local set_deck_winRef = set_deck_win
 function set_deck_win()
-	if isAPProfileLoaded() then
-		if G.GAME.selected_back and G.GAME.selected_back.effect and G.GAME.selected_back.effect.center and G.GAME.selected_back.effect.center.key then
-			local deck_key = G.GAME.selected_back.effect.center.key
-			if not G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key] then G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key] = {count = 1, order = G.GAME.selected_back.effect.center.order, wins = {}, losses = {}} end
-			if G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key] then
-				G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key].wins[G.GAME.stake] = (G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key].wins[G.GAME.stake] or 0) + 1
-			end
-			set_challenge_unlock()
-			G:save_settings()
-		end
-	else
-		return set_deck_winRef()
-	end
+    if isAPProfileLoaded() then
+        if G.GAME.selected_back and G.GAME.selected_back.effect and G.GAME.selected_back.effect.center and
+            G.GAME.selected_back.effect.center.key then
+            local deck_key = G.GAME.selected_back.effect.center.key
+            if not G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key] then
+                G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key] = {
+                    count = 1,
+                    order = G.GAME.selected_back.effect.center.order,
+                    wins = {},
+                    losses = {}
+                }
+            end
+            if G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key] then
+                G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key].wins[G.GAME.stake] =
+                    (G.PROFILES[G.SETTINGS.profile].deck_usage[deck_key].wins[G.GAME.stake] or 0) + 1
+            end
+            set_challenge_unlock()
+            G:save_settings()
+        end
+    else
+        return set_deck_winRef()
+    end
 end
 
 -- stakes button
 local GUIDEFrun_infoRef = G.UIDEF.run_info
 function G.UIDEF.run_info()
-	local _run_info = GUIDEFrun_infoRef()
-	
-	if isAPProfileLoaded() then
-		local _stake_slot = G.GAME.stake
-		G.GAME.stake = G.P_CENTER_POOLS.Stake[_stake_slot].stake_level
-		_run_info = GUIDEFrun_infoRef()
-		G.GAME.stake = _stake_slot
-	end
+    local _run_info = GUIDEFrun_infoRef()
 
-	return _run_info
+    if isAPProfileLoaded() then
+        local _stake_slot = G.GAME.stake
+        G.GAME.stake = G.P_CENTER_POOLS.Stake[_stake_slot].stake_level
+        _run_info = GUIDEFrun_infoRef()
+        G.GAME.stake = _stake_slot
+    end
+
+    return _run_info
 end
 
 -- "also applies" in stakes menu
 local GUIDEFcurrent_stakeRef = G.UIDEF.current_stake
 function G.UIDEF.current_stake()
-	local _current_stake = GUIDEFcurrent_stakeRef()
-	
-	if isAPProfileLoaded() then
-		local _stake_slot = G.GAME.stake
-		G.GAME.stake = G.P_CENTER_POOLS.Stake[_stake_slot].stake_level
-		_current_stake = GUIDEFcurrent_stakeRef()
-		G.GAME.stake = _stake_slot
-	end
-	
-	return _current_stake
-end
+    local _current_stake = GUIDEFcurrent_stakeRef()
 
+    if isAPProfileLoaded() then
+        local _stake_slot = G.GAME.stake
+        G.GAME.stake = G.P_CENTER_POOLS.Stake[_stake_slot].stake_level
+        _current_stake = GUIDEFcurrent_stakeRef()
+        G.GAME.stake = _stake_slot
+    end
+
+    return _current_stake
+end
 
 -- handle shop cards
 
@@ -1678,7 +1879,8 @@ end
 
 function get_shop_location()
     if G.AP.slot_data["stake" .. tostring(G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level) .. "_shop_locations"] then
-        for i, v in ipairs(G.AP.slot_data["stake" .. tostring(G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level) .. "_shop_locations"]) do
+        for i, v in ipairs(G.AP.slot_data["stake" .. tostring(G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level) ..
+                               "_shop_locations"]) do
             if (tableContains(G.APClient.missing_locations, v)) then
                 G.FUNCS.resolve_location_id_to_name(v)
                 return v
@@ -1896,7 +2098,8 @@ function check_for_unlock(args)
 
             for k, v in pairs(deck_list) do
                 if deck_name == v then
-                    sendLocationCleared(G.AP.id_offset + (64 * k) + (args.ante - 2) * 8 + (G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level - 1))
+                    sendLocationCleared(G.AP.id_offset + (64 * k) + (args.ante - 2) * 8 +
+                                            (G.P_CENTER_POOLS.Stake[G.GAME.stake].stake_level - 1))
                     break -- break the loop once the correct deck is found
                 end
             end
@@ -1958,53 +2161,77 @@ end
 local create_UIBox_notify_alertRef = create_UIBox_notify_alert
 function create_UIBox_notify_alert(_achievement, _type)
     if isAPProfileLoaded() and
-        (_type == "location" or _type == "Booster" or _type == "Tarot" or _type == "Planet" or _type == "Spectral"
-		or (_type == "Joker" and G.P_CENTERS[_achievement].soul_pos)) or _type == "Stake" or _type == "BackStake" then
+        (_type == "location" or _type == "Booster" or _type == "Tarot" or _type == "Planet" or _type == "Spectral" or
+            (_type == "Joker" and G.P_CENTERS[_achievement].soul_pos)) or _type == "Stake" or _type == "BackStake" then
 
         local _c, _atlas = G.P_CENTERS[_achievement],
             _type == "Tarot" and G.ASSET_ATLAS["Tarot"] or _type == "Planet" and G.ASSET_ATLAS["Tarot"] or _type ==
                 "Spectral" and G.ASSET_ATLAS["Tarot"] or _type == "Booster" and G.ASSET_ATLAS["Booster"] or _type ==
-                "location" and G.ASSET_ATLAS["rand_ap_logo"] or _type == 'Stake' and G.ASSET_ATLAS["chips"] or _type == 
-		'BackStake' and G.ASSET_ATLAS["centers"] or _type == 'Joker' and G.ASSET_ATLAS["Joker"] or G.ASSET_ATLAS["icons"]
+                "location" and G.ASSET_ATLAS["rand_ap_logo"] or _type == 'Stake' and G.ASSET_ATLAS["chips"] or _type ==
+                'BackStake' and G.ASSET_ATLAS["centers"] or _type == 'Joker' and G.ASSET_ATLAS["Joker"] or
+                G.ASSET_ATLAS["icons"]
 
-	--stake-specific _c
-	if _type == 'Stake' then
-		_c = {pos = {x = 0, y = 0}}
-		for i = 1, 8, 1 do
-			if G.P_CENTER_POOLS.Stake[i].key == _achievement then
-				_c.pos = G.P_CENTER_POOLS.Stake[i].pos
-				_c.name = G.P_CENTER_POOLS.Stake[i].name
-				break
-			end
-		end
-	end
-	
-	if _type == 'BackStake' then
-		_c = {pos = {x = 0, y = 0}, soul_pos = {x = 0, y = 0}, name = ""}
-		for i = 1, 8, 1 do
-			if string.find(_achievement, G.P_CENTER_POOLS.Stake[i].key) then
-				_c.soul_pos = G.P_CENTER_POOLS.Stake[i].sticker_pos
-				_c.name = G.P_CENTER_POOLS.Stake[i].name.." ("
-				break
-			end
-		end
-		
-		for k, v in pairs(G.P_CENTER_POOLS.Back) do
-			if string.find(_achievement, G.P_CENTER_POOLS.Back[k].key) then
-				_c.pos = G.P_CENTER_POOLS.Back[k].pos
-				_c.name = _c.name..G.P_CENTER_POOLS.Back[k].name..")"
-				break
-			end
-		end
-	end
-	
+        -- stake-specific _c
+        if _type == 'Stake' then
+            _c = {
+                pos = {
+                    x = 0,
+                    y = 0
+                }
+            }
+            for i = 1, 8, 1 do
+                if G.P_CENTER_POOLS.Stake[i].key == _achievement then
+                    _c.pos = G.P_CENTER_POOLS.Stake[i].pos
+                    _c.name = G.P_CENTER_POOLS.Stake[i].name
+                    break
+                end
+            end
+        end
+
+        if _type == 'BackStake' then
+            _c = {
+                pos = {
+                    x = 0,
+                    y = 0
+                },
+                soul_pos = {
+                    x = 0,
+                    y = 0
+                },
+                name = ""
+            }
+            for i = 1, 8, 1 do
+                if string.find(_achievement, G.P_CENTER_POOLS.Stake[i].key) then
+                    _c.soul_pos = G.P_CENTER_POOLS.Stake[i].sticker_pos
+                    _c.name = G.P_CENTER_POOLS.Stake[i].name .. " ("
+                    break
+                end
+            end
+
+            for k, v in pairs(G.P_CENTER_POOLS.Back) do
+                if string.find(_achievement, G.P_CENTER_POOLS.Back[k].key) then
+                    _c.pos = G.P_CENTER_POOLS.Back[k].pos
+                    _c.name = _c.name .. G.P_CENTER_POOLS.Back[k].name .. ")"
+                    break
+                end
+            end
+        end
+
         if not _c then
             if _type == "location" then
-                _c = {pos = {x = 0,
-                        y = 0}}
+                _c = {
+                    pos = {
+                        x = 0,
+                        y = 0
+                    }
+                }
             else -- moved to handle the trophy here because we need to set the x.y manually here for other icons anyway
-                _c = {pos = {x = 3,
-                        y = 0}}
+                _c = {
+                    pos = {
+                        x = 3,
+                        y = 0
+                    }
+                }
             end -- there's probably a better way, but idk
         end
 
@@ -2013,35 +2240,40 @@ function create_UIBox_notify_alert(_achievement, _type)
         t_s.states.hover.can = false
         t_s.states.collide.can = false
 
-	-- gold stake shader
-	if _type == 'Stake' then
-		if _achievement == "stake_gold" then
-			t_s.draw = function(_sprite)
-				_sprite.ARGS.send_to_shader = _sprite.ARGS.send_to_shader or {}
-				_sprite.ARGS.send_to_shader[1] = math.min(_sprite.VT.r*3, 1) + G.TIMERS.REAL/(18) + (_sprite.juice and _sprite.juice.r*20 or 0) + 1
-				_sprite.ARGS.send_to_shader[2] = G.TIMERS.REAL
+        -- gold stake shader
+        if _type == 'Stake' then
+            if _achievement == "stake_gold" then
+                t_s.draw = function(_sprite)
+                    _sprite.ARGS.send_to_shader = _sprite.ARGS.send_to_shader or {}
+                    _sprite.ARGS.send_to_shader[1] = math.min(_sprite.VT.r * 3, 1) + G.TIMERS.REAL / (18) +
+                                                         (_sprite.juice and _sprite.juice.r * 20 or 0) + 1
+                    _sprite.ARGS.send_to_shader[2] = G.TIMERS.REAL
 
-				Sprite.draw_shader(_sprite, 'dissolve')
-				Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
-			end
-		end
-	end
-	
-	-- second layer for the soul, the hologramm and the legendaries
-	if (_c and _c.soul_pos) or _achievement == 'c_soul' then
-		local _soul_atlas = _achievement == 'c_soul' and G.ASSET_ATLAS["centers"] or 
-			_type == 'BackStake' and G.ASSET_ATLAS["stickers"] or G.ASSET_ATLAS["Joker"]
-		local _soul_pos = _achievement == 'c_soul' and {x = 0, y = 1} or _c.soul_pos
-		local _soul_t_s = Sprite(t_s.T.x,t_s.T.y,1.5*(_soul_atlas.px/_soul_atlas.py),1.5,_soul_atlas, _soul_pos)
-		_soul_t_s.states.drag.can = false
-		_soul_t_s.states.hover.can = false
-		_soul_t_s.states.collide.can = false
-		
-		t_s.children.floating_sprite = _soul_t_s
-		t_s.children.floating_sprite.role.draw_major = t_s
-		_soul_t_s.T = t_s.T
-		_soul_t_s.VT = t_s.VT
-	end
+                    Sprite.draw_shader(_sprite, 'dissolve')
+                    Sprite.draw_shader(_sprite, 'voucher', nil, _sprite.ARGS.send_to_shader)
+                end
+            end
+        end
+
+        -- second layer for the soul, the hologramm and the legendaries
+        if (_c and _c.soul_pos) or _achievement == 'c_soul' then
+            local _soul_atlas = _achievement == 'c_soul' and G.ASSET_ATLAS["centers"] or _type == 'BackStake' and
+                                    G.ASSET_ATLAS["stickers"] or G.ASSET_ATLAS["Joker"]
+            local _soul_pos = _achievement == 'c_soul' and {
+                x = 0,
+                y = 1
+            } or _c.soul_pos
+            local _soul_t_s = Sprite(t_s.T.x, t_s.T.y, 1.5 * (_soul_atlas.px / _soul_atlas.py), 1.5, _soul_atlas,
+                _soul_pos)
+            _soul_t_s.states.drag.can = false
+            _soul_t_s.states.hover.can = false
+            _soul_t_s.states.collide.can = false
+
+            t_s.children.floating_sprite = _soul_t_s
+            t_s.children.floating_sprite.role.draw_major = t_s
+            _soul_t_s.T = t_s.T
+            _soul_t_s.VT = t_s.VT
+        end
 
         local subtext = "Location cleared"
         local name = "Archipelago"

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -616,6 +616,19 @@ G.FUNCS.AP_unlock_stake = function(stake_name)
     end
 end
 
+G.FUNCS.AP_unlock_stake_per_deck = function(stake_key, deck_key)
+
+    sendDebugMessage("Unlocking " .. tostring(stake_key) .. " for deck " .. tostring(deck_key))
+    G.PROFILES[G.AP.profile_Id].deck_usage[deck_key].stake_unlocks[stake_key] = true
+
+    if G.AP.StakesInit then
+        notify_alert(stake_key .. deck_key, 'BackStake')
+    end
+
+
+   
+end
+
 local game_init_item_prototypesRef = Game.init_item_prototypes
 function Game:init_item_prototypes()
     local game_init_item_prototypes = game_init_item_prototypesRef(self)
@@ -844,7 +857,6 @@ end
 
 -- handle stakes
 
-
 -- reinsert the stakes in the desired order, removing the modded ones
 function init_AP_stakes()
 	
@@ -1027,7 +1039,11 @@ function init_AP_stakes()
 
     -- empty queue
     for i = 1, #G.AP.StakeQueue do
-		G.FUNCS.AP_unlock_stake(G.AP.StakeQueue[i])
+        if type(G.AP.StakeQueue[i]) == "table" then
+            G.FUNCS.AP_unlock_stake_per_deck(G.AP.StakeQueue[i].stake, G.AP.StakeQueue[i].deck)
+        elseif type(G.AP.StakeQueue[i]) == "string" then
+            G.FUNCS.AP_unlock_stake(G.AP.StakeQueue[i])
+        end    
 	end
 
     G.AP.StakeQueue = {}


### PR DESCRIPTION
- Fixed stack overflow related to recursive stake checks.
- Fixed "Also applies" window.
- Added Trap notifications.
     - Eternal, Perishable and Rental traps are rendered as a negative Joker with their respective sticker
     - Lose a hand/discard/all money are rendered as negative Grabber, Wasteful and Liquidation
- Added new goals.
     - Goal 3: Beat # Decks on at least # Stake difficulty.
     - Goal 4: Win with # Jokers on at least # Stake difficulty.

had to do a quick syntax fix