### PR TITLE
Ejection Update + preparations for Challenge Update

### DIFF
--- a/UIdefinitions.lua
+++ b/UIdefinitions.lua
@@ -942,3 +942,33 @@ function UIDEF_alert_extra_ui(card, price, badge)
         }
     end
 end
+
+--Add Challenge Deck into the pool when opening the deck collection
+local create_UIBox_your_collection_decksRef = create_UIBox_your_collection_decks
+function create_UIBox_your_collection_decks()
+	local _result = nil
+	if isAPProfileLoaded() and
+        tableContains(G.P_CENTER_POOLS.Back, G.P_CENTERS['b_challenge']) == false then
+		    G.P_CENTER_POOLS.Back[#G.P_CENTER_POOLS.Back+1] = G.P_CENTERS['b_challenge']
+		    G.P_CENTERS['b_challenge'].name = "ChaIIenge Deck" --need this to avoid a crash
+	end
+	_result = create_UIBox_your_collection_decksRef()
+	return _result
+end
+
+--Remove Challenge Deck from the pool when closing the deck collection
+local create_UIBox_your_collectionRef = create_UIBox_your_collection
+function create_UIBox_your_collection()
+	local _result = nil
+    if isAPProfileLoaded() then
+    	for k, v in ipairs(G.P_CENTER_POOLS.Back) do
+    		if v == G.P_CENTERS['b_challenge'] then
+    			G.P_CENTERS['b_challenge'].name = "Challenge Deck"
+    			table.remove(G.P_CENTER_POOLS.Back, k)
+    			break
+    		end
+    	end
+    end
+	_result = create_UIBox_your_collectionRef()
+	return _result
+end

--- a/UIdefinitions.lua
+++ b/UIdefinitions.lua
@@ -972,3 +972,33 @@ function create_UIBox_your_collection()
 	_result = create_UIBox_your_collectionRef()
 	return _result
 end
+
+--fix stake cursor and/or challenge deck in the pool
+local GUIDEFrun_setup_option = G.UIDEF.run_setup_option
+function G.UIDEF.run_setup_option(type)
+	if isAPProfileLoaded() then
+		
+		if not G.SAVED_GAME then
+			G.SAVED_GAME = get_compressed(G.SETTINGS.profile..'/'..'save.jkr')
+			if G.SAVED_GAME ~= nil then G.SAVED_GAME = STR_UNPACK(G.SAVED_GAME) end
+		end
+
+		--remove challenge deck from main pool if its there somehow
+		for k, v in ipairs(G.P_CENTER_POOLS.Back) do
+    			if v == G.P_CENTERS['b_challenge'] then
+    				G.P_CENTERS['b_challenge'].name = "Challenge Deck"
+    				table.remove(G.P_CENTER_POOLS.Back, k)
+    				break
+    			end
+    		end
+		
+		-- fix AP stake cursor when viewing the continue screen
+		if G.SAVED_GAME ~= nil then
+			saved_game = G.SAVED_GAME
+			G.viewed_stake = saved_game.GAME.stake or 1
+			G.viewed_stake_act[2] = saved_game.GAME.stake or 1
+			G.viewed_stake_act[1] = 0
+		end
+	end
+	return GUIDEFrun_setup_option(type)
+end

--- a/UIdefinitions.lua
+++ b/UIdefinitions.lua
@@ -1002,3 +1002,90 @@ function G.UIDEF.run_setup_option(type)
 	end
 	return GUIDEFrun_setup_option(type)
 end
+
+--challenge ui
+local GUIDEFchallengesRef = G.UIDEF.challenges
+function G.UIDEF.challenges(from_game_over)
+	if isAPProfileLoaded() then
+		G.PROFILES[G.SETTINGS.profile].challenges_unlocked = #G.CHALLENGES
+		local loc_nodes = {}
+		local _locked = true
+
+		--change this to enable challenges
+		local challenge_mode = 1000000
+		
+		-- vanilla requirement (beat # of decks)
+		if challenge_mode == 1 then
+			local _deck_wins = 0
+			local _deck_win_requirement = 10
+			
+			for k, v in pairs(G.PROFILES[G.SETTINGS.profile].deck_usage) do
+				if v.wins and #v.wins > 0 then
+					_deck_wins = _deck_wins + 1
+					if _deck_wins >= _deck_win_requirement then
+						_locked = false
+						break
+					end
+				end
+			end
+			localize{type = 'descriptions', key = 'ap_challenge_locked_vanilla', set = 'Other', nodes = loc_nodes, vars = {_deck_win_requirement, _deck_wins}, default_col = G.C.WHITE}
+		
+		-- find the challenge deck as an AP item
+		elseif challenge_mode == 2 then
+			localize{type = 'descriptions', key = 'ap_challenge_locked_deck', set = 'Other', nodes = loc_nodes, default_col = G.C.WHITE}
+			_locked = not G.P_CENTERS['b_challenge'].unlocked
+		
+		-- find any challenge as an AP item
+		elseif challenge_mode == 3 then
+			localize{type = 'descriptions', key = 'ap_challenge_locked_item', set = 'Other', nodes = loc_nodes, default_col = G.C.WHITE}
+			for k, v in pairs(G.CHALLENGES) do
+				if v.unlocked == true then
+					_locked = false
+					break
+				end
+			end
+			
+		-- unlocked from the start (doesnt unlock the challenges themselves LOL)
+		elseif challenge_mode == 4 then
+			_locked = false
+			
+		-- default to disabling challenges
+		else
+			localize{type = 'descriptions', key = 'ap_challenge_locked_none', set = 'Other', nodes = loc_nodes, default_col = G.C.WHITE}
+			
+		end
+		
+		local _result = {
+			n = G.UIT.ROOT, 
+			config = {
+				align = "cm",
+				padding = 0.1,
+				colour = G.C.CLEAR,
+				minh = 8.02,
+				minw = 7
+			},
+			nodes = {
+				transparent_multiline_text(loc_nodes)
+				}
+		}
+		
+		--lock the player out if they fail to meet the requirement
+		if _locked then
+			return _result
+		else -- count the amount of unlocked challenges
+			G.PROFILES[G.SETTINGS.profile].challenges_unlocked = 0
+			for k, v in pairs(G.CHALLENGES) do
+				if v.unlocked == true then
+					G.PROFILES[G.SETTINGS.profile].challenges_unlocked = G.PROFILES[G.SETTINGS.profile].challenges_unlocked + 1
+				end
+			end
+		end
+	end
+	local challenges_ui = GUIDEFchallengesRef(from_game_over)
+	
+	if isAPProfileLoaded() then
+		G.PROFILES[G.SETTINGS.profile].challenges_unlocked = #G.CHALLENGES
+	end
+	
+	return challenges_ui
+end

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -24,8 +24,8 @@ return {
 		Back = {
 			b_challenge = {
 				text = {
-					"Angewandt {C:attention}Individuelle Regeln{}",
-					"und Beschränkungen"
+					"Hat {C:attention}individuelle Regeln{}",
+					"und Einschränkungen"
 				}
 			}
 		},

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -306,7 +306,7 @@ return {
                 text = {
                    --"{C:inactive,s:2}Herausforderungen sind deaktiviert"
 				   "Nicht verfügbar",
-                    "in diese Version",
+                    "in dieser Version",
 				   "{C:attention,s:2}Kommt bald!"
                 }
             },

--- a/localization/de.lua
+++ b/localization/de.lua
@@ -21,6 +21,14 @@ return {
 				}
 			}
 		},
+		Back = {
+			b_challenge = {
+				text = {
+					"Angewandt {C:attention}Individuelle Regeln{}",
+					"und Beschränkungen"
+				}
+			}
+		},
 		Trap = { -- Trap names are NOT used
 			t_eternal = {
 				name = "Ewig-Falle",
@@ -266,6 +274,47 @@ return {
 				text = {
 					"Finde dieses Booster-Paket",
 					"als {C:dark_edition}AP item"
+				}
+			},
+			ap_challenge_locked_vanilla = {
+                name = "Gesperrt",
+                text = {
+                    "Gewinne mindestens einen Durchlauf",
+                    "mit #1# unterschiedlichen Decks,",
+                    "um den Herausforderungsmodus freizuschalten",
+                    "{C:attention,s:2}#2#/#1#"
+                }
+            },
+			ap_challenge_locked_deck = {
+                name = "Gesperrt",
+                text = {
+                    "Finde das Herausforderungsdeck",
+                    "als {C:dark_edition}AP Item{},",
+                    "um den Herausforderungsmodus freizuschalten"
+                }
+            },
+			ap_challenge_locked_item = {
+                name = "Gesperrt",
+                text = {
+                    "Finde jede Herausforderung",
+                    "als {C:dark_edition}AP Item{},"
+                    "um den Herausforderungsmodus freizuschalten"
+                }
+            },
+			ap_challenge_locked_none = {
+                name = "Gesperrt",
+                text = {
+                   --"{C:inactive,s:2}Herausforderungen sind deaktiviert"
+				   "Nicht verfügbar",
+                    "in diese Version",
+				   "{C:attention,s:2}Kommt bald!"
+                }
+            },
+			ap_locked_Deck_c = { --temporary
+				name = "Gesperrt",
+				text = {
+					"Nicht verfügbar",
+                    "in dieser Version"
 				}
 			},
 			ap_goal_decks = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -22,6 +22,14 @@ return {
 				}
 			}
 		},
+		Back = {
+			b_challenge = {
+				text = {
+					"Applies {C:attention}Custom Rules{}",
+					"and restrictions"
+				}
+			}
+		},
 		Trap = { -- Trap names are NOT used
 			t_eternal = {
 				name = "Eternal Trap",
@@ -267,6 +275,47 @@ return {
 				text = {
 					"Find this Booster Pack",
 					"as an {C:dark_edition}AP item"
+				}
+			},
+			ap_challenge_locked_vanilla = {
+                name = "Locked",
+                text = {
+                    "Win a run with at least",
+                    "#1# different decks to unlock",
+                    "Challenge mode",
+                    "{C:attention,s:2}#2#/#1#"
+                }
+            },
+			ap_challenge_locked_deck = {
+                name = "Locked",
+                text = {
+                    "Find the Challenge Deck",
+                    "as an {C:dark_edition}AP Item{} to unlock",
+                    "Challenge mode"
+                }
+            },
+			ap_challenge_locked_item = {
+                name = "Locked",
+                text = {
+                    "Find any Challenge",
+                    "as an {C:dark_edition}AP Item{} to unlock",
+                    "Challenge mode"
+                }
+            },
+			ap_challenge_locked_none = {
+                name = "Locked",
+                text = {
+                   --"{C:inactive,s:2}Challenges are disabled"
+				   "Not available",
+                   "in this version",
+				   "{C:attention,s:2}Coming Soon!"
+                }
+            },
+			ap_locked_Deck_c = { --temporary
+				name = "Locked",
+				text = {
+					"Not available",
+                    "in this version"
 				}
 			},
 			ap_goal_decks = {

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -22,6 +22,14 @@ return {
 				}
 			}
 		},
+		Back = {
+			b_challenge = {
+				text = {
+					"Применяет {C:attention}Особые правила{}",
+					"и ограничения"
+				}
+			}
+		},
 		Trap = { -- Trap names are NOT used
 			t_eternal = {
 				name = "Вечная Ловушка",
@@ -267,6 +275,47 @@ return {
 				text = {
 					"Найдите этот набор",
 					"в виде {C:dark_edition}Айтема AP"
+				}
+			},
+			ap_challenge_locked_vanilla = {
+                name = "Заблокировано",
+                text = {
+                    "Выиграйте партию с минимум",
+                    "#1# разными колодами, чтобы открыть",
+                    "режим испытания",
+                    "{C:attention,s:2}#2#/#1#"
+                }
+            },
+			ap_challenge_locked_deck = {
+                name = "Заблокировано",
+                text = {
+                    "Найдите Колоду испытаний",
+                    "в виде {C:dark_edition}Айтема AP{}, чтобы открыть",
+                    "режим испытания"
+                }
+            },
+			ap_challenge_locked_item = {
+                name = "Заблокировано",
+                text = {
+                    "Найдите любое Испытание",
+                    "в виде {C:dark_edition}Айтема AP{}, чтобы открыть",
+                    "режим испытания"
+                }
+            },
+			ap_challenge_locked_none = {
+                name = "Заблокировано",
+                text = {
+                   --"{C:inactive,s:2}Испытания отключены."
+				   "Недоступно",
+                   "в этой версии",
+				   "{C:attention,s:2}Скоро!"
+                }
+            },
+			ap_locked_Deck_c = { --temporary
+				name = "Locked",
+				text = {
+					"Недоступно",
+                    "в этой версии"
 				}
 			},
 			ap_goal_decks = {

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -825,7 +825,8 @@ function CardArea:emplace(card, location, stay_flipped)
             G.pack_cards)) or (card.config.center_key == "j_joker" and card.config.center.unlocked == true) or
         (card.config.center_key == "c_pluto" and card.config.center.unlocked == true) or
         (card.config.center_key == "c_strength" and card.config.center.unlocked == true) or
-        (card.config.center_key == "c_incantation" and card.config.center.unlocked == true)) then
+        (card.config.center_key == "c_incantation" and card.config.center.unlocked == true)) 
+        and tableContains(G.your_collection, self) == false then
 
         -- following blocks handle standard cards appearing in packs/shop
         if not next(find_joker("Showman")) and card.config.center.unlocked == true then

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -528,7 +528,7 @@ function Game:init_item_prototypes()
                     end
                 end
                 -- for backs (decks)
-            elseif string.find(k, '^b_') and k ~= 'b_challenge' then
+            elseif string.find(k, '^b_') then
                 v.unlocked = false
                 G.AP.UnlockConsCache[k] = v.unlock_condition
                 v.unlock_condition = nil
@@ -541,7 +541,7 @@ function Game:init_item_prototypes()
                     end
                 end
 
-                if not tableContains(G.AP.slot_data.included_decks, k) then
+                if not tableContains(G.AP.slot_data.included_decks, k) and k ~= 'b_challenge' then
                     SMODS.Back:take_ownership(k, {}):delete()
                 elseif not standard_deck then
                     standard_deck = k
@@ -734,6 +734,17 @@ function Game:init_item_prototypes()
                 self.P_CENTERS[k].demo = nil
             end
         end
+        
+        --fix some custom implementation of the Challenge Deck
+        G.P_CENTERS['b_challenge'].name = "Challenge Deck"
+        G.P_CENTERS['b_challenge'].unlocked = true
+        --remove it from the pool if its there somehow
+        for k, v in ipairs(G.P_CENTER_POOLS.Back) do
+    		if v == G.P_CENTERS['b_challenge'] then
+    			table.remove(G.P_CENTER_POOLS.Back, k)
+    			break
+    		end
+    	end
     end
     return game_init_item_prototypes
 end
@@ -1572,6 +1583,18 @@ function check_and_set_high_score(score, amt)
         G.GAME.round_scores[score].amt = 0
     end
     return check_and_set_high_scoreRef(score, amt)
+end
+
+--prevent modded centers from being injected for AP
+local SMODScenter_injectRef = SMODS.Center.inject 
+function SMODS.Center.inject(self)
+	if isAPProfileLoaded() then
+		if self.mod == nil or self.key == 'v_rand_ap_item' then
+			SMODScenter_injectRef(self)
+		end
+	else 
+		SMODScenter_injectRef(self)
+	end
 end
 
 ----------------------------------------------

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -6,6 +6,7 @@
 --- PREFIX: rand
 --- BADGE_COLOR: 4E8BE6
 --- DISPLAY_NAME: Archipelago
+--- VERSION: 0.1.7
 ----------------------------------------------
 ------------MOD CODE -------------------------
 G.AP = {
@@ -458,8 +459,10 @@ function Game:init_item_prototypes()
         -- everything else uses "Other.demo_locked" and overwrites it with their text (not here)
         for k, v in pairs(G.localization.descriptions.Back) do
             v.unlock_parsed = {}
-
-            for _line, _string in pairs(G.localization.descriptions.Other.ap_locked_Back.text_parsed) do
+			local loc_target = k == 'b_challenge' and G.localization.descriptions.Other.ap_locked_Back_c.text_parsed 
+				or G.localization.descriptions.Other.ap_locked_Back.text_parsed
+			
+            for _line, _string in pairs(loc_target) do
                 v.unlock_parsed[_line] = _string
             end
 
@@ -1164,7 +1167,7 @@ SMODS.Voucher {
     end,
     set_card_type_badge = function(self, card, badges)
         if card.ability and card.ability.sprite == 1 then
-            badges[#badges + 1] = create_badge(localize("k_ap_check"), HEX("7749a8"), nil, 1.2)
+            badges[#badges + 1] = create_badge(localize("k_ap_check"), {0.4666, 0.286, 0.6588, 1}, nil, 1.2)
         else
             badges[#badges + 1] = create_badge(localize("k_ap_check"), G.C.DARK_EDITION, nil, 1.2)
         end

--- a/stake.lua
+++ b/stake.lua
@@ -339,28 +339,6 @@ function check_stake_unlock(_stake, _deck_key)
     return false
 end
 
-local GUIDEFrun_setup_option = G.UIDEF.run_setup_option
-function G.UIDEF.run_setup_option(type)
-    if isAPProfileLoaded() then
-
-        if not G.SAVED_GAME then
-            G.SAVED_GAME = get_compressed(G.SETTINGS.profile .. '/' .. 'save.jkr')
-            if G.SAVED_GAME ~= nil then
-                G.SAVED_GAME = STR_UNPACK(G.SAVED_GAME)
-            end
-        end
-
-        -- fix AP stake cursor when viewing the continue screen
-        if G.SAVED_GAME ~= nil then
-            saved_game = G.SAVED_GAME
-            G.viewed_stake = saved_game.GAME.stake or 1
-            G.viewed_stake_act[2] = saved_game.GAME.stake or 1
-            G.viewed_stake_act[1] = 0
-        end
-    end
-    return GUIDEFrun_setup_option(type)
-end
-
 local UIDEF_deck_stake_columnRef = G.UIDEF.deck_stake_column
 function G.UIDEF.deck_stake_column(_deck_key)
     -- hijack to use custom logic in AP


### PR DESCRIPTION
- modded centers are now ejected from the game when loading into archipelago

- modded challenges are now ejected from the game when loading into archipelago
- added function to control when challenges unlock (challenges are disabled by default)
- challenge deck now shows up in the collection
     - added custom description for challenge deck (vanilla lacks one) 

- fix emplace removing collection cards when viewing the shop
- fix ap item counting as a voucher applied to the run

- added a version number into the metadata
- updated localization files