### PR TITLE
0.1.9b - fix hints, minor additions

### DIFF
--- a/UIdefinitions.lua
+++ b/UIdefinitions.lua
@@ -749,7 +749,7 @@ function Card:generate_UIBox_ability_table()
 							
 							G.localization.descriptions.Other.debuffed_default.text_parsed = target_text
 						else
-							G.localization.descriptions.Other.demo_locked.text_parsed = target_text
+							G.localization.descriptions.Other.wip_locked.text_parsed = target_text
 							
 							local _loc_target = nil
 							
@@ -765,8 +765,8 @@ function Card:generate_UIBox_ability_table()
 							end
 							
 							if _loc_target then
-								G.localization.descriptions.Other.demo_locked.text_parsed[#G.localization.descriptions.Other
-									.demo_locked.text_parsed + 1] = loc_parse_string(
+								G.localization.descriptions.Other.wip_locked.text_parsed[#G.localization.descriptions.Other
+									.wip_locked.text_parsed + 1] = loc_parse_string(
 									"{C:inactive,s:0.8}(" .. _loc_target.name .. ")")
 							end
 						end
@@ -802,23 +802,23 @@ function Card:generate_UIBox_ability_table()
 
         if self.config.center.unlocked == false then -- locked message
             if G.localization.descriptions.Other["ap_locked_" .. self.config.center.set] then
-                G.localization.descriptions.Other.demo_locked.text_parsed = {}
+                G.localization.descriptions.Other.wip_locked.text_parsed = {}
                 for k, v in pairs(G.localization.descriptions.Other["ap_locked_" .. self.config.center.set].text_parsed) do
-                    G.localization.descriptions.Other.demo_locked.text_parsed[k] = v
+                    G.localization.descriptions.Other.wip_locked.text_parsed[k] = v
                 end
             end
             
             -- modded item locked message
             if G.AP.this_mod.config.modded == 2 and self.config.center.modded then
-                G.localization.descriptions.Other.demo_locked.text_parsed = {}
+                G.localization.descriptions.Other.wip_locked.text_parsed = {}
                 for k, v in pairs(G.localization.descriptions.Other["ap_locked_Modded"].text_parsed) do
-                    G.localization.descriptions.Other.demo_locked.text_parsed[k] = v
+                    G.localization.descriptions.Other.wip_locked.text_parsed[k] = v
                 end
             end
 
             if self.config.center.set ~= "Booster" then
-                G.localization.descriptions.Other.demo_locked.text_parsed[#G.localization.descriptions.Other
-                    .demo_locked.text_parsed + 1] = loc_parse_string("{C:inactive,s:0.8}(" ..
+                G.localization.descriptions.Other.wip_locked.text_parsed[#G.localization.descriptions.Other
+                    .wip_locked.text_parsed + 1] = loc_parse_string("{C:inactive,s:0.8}(" ..
                                                                          G.localization.descriptions[self.config
                                                                              .center.set][self.config.center.key]
                                                                              .name .. ")")
@@ -832,8 +832,8 @@ function Card:generate_UIBox_ability_table()
                 end
 
                 if _loc_target then
-                    G.localization.descriptions.Other.demo_locked.text_parsed[#G.localization.descriptions.Other
-                        .demo_locked.text_parsed + 1] = loc_parse_string(
+                    G.localization.descriptions.Other.wip_locked.text_parsed[#G.localization.descriptions.Other
+                        .wip_locked.text_parsed + 1] = loc_parse_string(
                         "{C:inactive,s:0.8}(" .. _loc_target.name .. ")")
                 end
             end

--- a/UIdefinitions.lua
+++ b/UIdefinitions.lua
@@ -907,6 +907,9 @@ function localizeApHint(_hint, _center)
 					if G.P_CENTER_POOLS.Stake[i].key == _stake then
 						loc_colour()
 						G.ARGS.LOC_COLOURS.ap_stake = G.P_CENTER_POOLS.Stake[i].colour
+						if G.P_CENTER_POOLS.Stake[i].key == 'stake_white' then
+							G.ARGS.LOC_COLOURS.ap_stake = G.C.FILTER
+						end
 						break
 					end
 				end

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -627,7 +627,7 @@ function APConnect()
 
 					if G.jokers and G.jokers.cards then
 						for k, v in pairs(G.jokers.cards) do
-							if v and type(v) == 'table' and v.config.center.name == item.name then
+							if v and type(v) == 'table' and v.config.center.key == item.key then
 								v:set_debuff(false)
 							end
 						end
@@ -635,7 +635,7 @@ function APConnect()
 
 					if G.consumeables and G.consumeables.cards then
 						for k, v in pairs(G.consumeables.cards) do
-							if v and type(v) == 'table' and v.config.center.name == item.name then
+							if v and type(v) == 'table' and v.config.center.key == item.key then
 								v:set_debuff(false)
 							end
 						end
@@ -644,14 +644,14 @@ function APConnect()
 					if G.STATES then
 						if G.STATE == G.STATES.SHOP and G.shop_jokers and G.shop_jokers.cards then
 							for k, v in pairs(G.shop_jokers.cards) do
-								if v and type(v) == 'table' and v.config.center.name == item.name then
+								if v and type(v) == 'table' and v.config.center.key == item.key then
 									v:set_debuff(false)
 								end
 							end
 						end
 						if G.STATE == G.STATES.BUFFOON_PACK and G.pack_cards and G.pack_cards.cards then
 							for k, v in pairs(G.pack_cards.cards) do
-								if v and type(v) == 'table' and v.config.center.name == item.name then
+								if v and type(v) == 'table' and v.config.center.key == item.key then
 									v:set_debuff(false)
 								end
 							end
@@ -662,7 +662,7 @@ function APConnect()
 				item.unlocked = true
 				item.discovered = true
 				item.hidden = false
-				item.demo = nil
+				item.wip = nil
 
 				-- spectral gimmick
 				if G.AP.Spectral.active == true and not G.AP.Spectral.item then

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1621,10 +1621,8 @@ G.AP.update_hints = function()
     G.AP.player_names = G.AP.player_names or {}
 	G.AP.hint_priotiy = G.AP.hint_priotiy or {}
 	if not G.E_MANAGER.queues.ap_hints then G.E_MANAGER.queues.ap_hints = {} end
-	if G.AP.hint_priotiy == 0 then
-		G.E_MANAGER:clear_queue('ap_hints')
-		G.AP.make_hint_step(1)
-	end
+	if #G.E_MANAGER.queues.ap_hints ~= 0 then G.E_MANAGER.clear_queue('ap_hints') end
+	G.AP.make_hint_step(1)
 end
 
 function G.AP.make_hint_step(i, hint)
@@ -1644,6 +1642,7 @@ function G.AP.make_hint_step(i, hint)
 							blocking = true,
 							pause_force = true,
 							func = function()
+								print("waiting on hint #"..tostring(i))
 								return G.AP.hint_locations[G.AP.hints[i].location]
 							end
 						}, 'ap_hints')
@@ -1653,9 +1652,8 @@ function G.AP.make_hint_step(i, hint)
 							blockable = true,
 							pause_force = true,
 							func = function()
-								if #G.AP.hint_priotiy == 0 then
-									G.AP.make_hint_step(i+1)
-								end
+								G.AP.make_hint_step(i+1)
+								print("queued hint #"..tostring(i+1))
 								return true
 							end
 						}, 'ap_hints')
@@ -1672,6 +1670,7 @@ function G.AP.make_hint_step(i, hint)
 								blocking = true,
 								pause_force = true,
 								func = function()
+									print("waiting on name for player "..tostring(finder))
 									return G.AP.player_names[finder]
 								end
 							}, 'ap_hints')
@@ -1681,9 +1680,8 @@ function G.AP.make_hint_step(i, hint)
 								blockable = true,
 								pause_force = true,
 								func = function()
-									if #G.AP.hint_priotiy == 0 then
-										G.AP.make_hint_step(i+1)
-									end
+									G.AP.make_hint_step(i+1)
+									print("queued hint #"..tostring(i+1))
 									return true
 								end
 							}, 'ap_hints')
@@ -1704,6 +1702,7 @@ function G.AP.make_hint_step(i, hint)
 					blocking = true,
 					pause_force = true,
 					func = function()
+						print("waiting on priority hint")
 						return G.AP.hint_locations[hint.location]
 					end
 				}, 'ap_hints')
@@ -1713,6 +1712,7 @@ function G.AP.make_hint_step(i, hint)
 					blockable = true,
 					pause_force = true,
 					func = function()
+						print("priority hint received")
 						G.AP.hint_priotiy[hint.location] = nil
 						return true
 					end

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1569,7 +1569,7 @@ function APConnect()
         for _, key in ipairs(keys) do
             if key == "_read_hints_" .. tostring(G.AP.team_id) .. "_" .. tostring(G.AP.player_id) then
                 G.AP.hints = map[key]
-                -- G.AP.update_hints()
+                G.AP.update_hints()
             end
             print("  " .. key .. ": " .. tostring(map[key]))
             if type(map[key]) == "table" then
@@ -1618,12 +1618,21 @@ end
 G.AP.update_hints = function()
     G.AP.hint_locations = G.AP.hint_locations or {}
     G.AP.player_names = G.AP.player_names or {}
+	local offset = 0
 
     for i = 1, #G.AP.hints do
         if G.AP.hints[i].found == false and not G.AP.hint_locations[G.AP.hints[i].location] then
             if G.AP.hints[i].finding_player == G.AP.player_id then
-                G.AP.hint_locations[G.AP.hints[i].location] =
-                    G.APClient:get_location_name(G.AP.hints[i].location, 'Balatro')
+				G.E_MANAGER:add_event(Event({
+					trigger = 'after', 
+					delay = 0.25*offset,
+					blocking = false,
+					blockable = false,
+					func = function()
+                		G.AP.hint_locations[G.AP.hints[i].location] =
+                    		G.APClient:get_location_name(G.AP.hints[i].location, 'Balatro')
+					return true end }))
+				offset = offset + 1
             else
                 -- non-local items just say they're not here
                 G.AP.hint_locations[G.AP.hints[i].location] = "nonlocal"

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1627,7 +1627,7 @@ G.AP.update_hints = function()
 	end
 end
 
-local G.AP.make_hint_step = function(i, hint)
+function G.AP.make_hint_step(i, hint)
 	local temp_pause = G.SETTINGS.paused
 	G.SETTINGS.paused = false
 	

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1569,7 +1569,7 @@ function APConnect()
         for _, key in ipairs(keys) do
             if key == "_read_hints_" .. tostring(G.AP.team_id) .. "_" .. tostring(G.AP.player_id) then
                 G.AP.hints = map[key]
-                G.AP.update_hints()
+                -- G.AP.update_hints()
             end
             print("  " .. key .. ": " .. tostring(map[key]))
             if type(map[key]) == "table" then
@@ -1615,6 +1615,7 @@ function APConnect()
     G.APClient:set_set_reply_handler(on_set_reply)
 end
 
+-- TODO: rethink the approach - perhaps cards should scout themselves?
 G.AP.update_hints = function()
     G.AP.hint_locations = G.AP.hint_locations or {}
     G.AP.player_names = G.AP.player_names or {}
@@ -1623,16 +1624,8 @@ G.AP.update_hints = function()
     for i = 1, #G.AP.hints do
         if G.AP.hints[i].found == false and not G.AP.hint_locations[G.AP.hints[i].location] then
             if G.AP.hints[i].finding_player == G.AP.player_id then
-				G.E_MANAGER:add_event(Event({
-					trigger = 'after', 
-					delay = 0.25*offset,
-					blocking = false,
-					blockable = false,
-					func = function()
-                		G.AP.hint_locations[G.AP.hints[i].location] =
-                    		G.APClient:get_location_name(G.AP.hints[i].location, 'Balatro')
-					return true end }))
-				offset = offset + 1
+				G.AP.hint_locations[G.AP.hints[i].location] =
+					G.APClient:get_location_name(G.AP.hints[i].location, 'Balatro')
             else
                 -- non-local items just say they're not here
                 G.AP.hint_locations[G.AP.hints[i].location] = "nonlocal"

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1569,7 +1569,7 @@ function APConnect()
         for _, key in ipairs(keys) do
             if key == "_read_hints_" .. tostring(G.AP.team_id) .. "_" .. tostring(G.AP.player_id) then
                 G.AP.hints = map[key]
-                G.AP.update_hints()
+                -- G.AP.update_hints()
             end
             print("  " .. key .. ": " .. tostring(map[key]))
             if type(map[key]) == "table" then

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -6,7 +6,7 @@
 --- PREFIX: rand
 --- BADGE_COLOR: 4E8BE6
 --- DISPLAY_NAME: Archipelago
---- VERSION: 0.1.9
+--- VERSION: 0.1.9b
 --- DEPENDENCIES: [Steamodded>=1.0.0~ALPHA-0829a]
 ----------------------------------------------
 ------------MOD CODE -------------------------
@@ -1212,6 +1212,7 @@ SMODS.Voucher {
         end
     end,
     loc_vars = function(self, info_queue, card)
+		if not card then return nil end -- sanity check
         if card.ability.extra.id == 0 then
             return {} -- no location = default description
         elseif G.APClient ~= nil and tableContains(G.APClient.missing_locations, card.ability.extra.id) then
@@ -1346,6 +1347,7 @@ SMODS.Consumable {
 		return true
 	end,
 	loc_vars = function(self, info_queue, card)
+		if not card then return nil end -- sanity check
         if card.ability.extra.id == 0 then
             return {} -- no location = default description
         elseif G.APClient ~= nil and tableContains(G.APClient.missing_locations, card.ability.extra.id) then
@@ -1515,6 +1517,7 @@ SMODS.Consumable {
 		return true
 	end,
 	loc_vars = function(self, info_queue, card)
+		if not card then return nil end -- sanity check
         if card.ability.extra.id == 0 then
             return {} -- no location = default description
         elseif G.APClient ~= nil and tableContains(G.APClient.missing_locations, card.ability.extra.id) then
@@ -1698,6 +1701,7 @@ SMODS.Consumable {
 		return true
 	end,
 	loc_vars = function(self, info_queue, card)
+		if not card then return nil end -- sanity check
         if card.ability.extra.id == 0 then
             return {} -- no location = default description
         elseif G.APClient ~= nil and tableContains(G.APClient.missing_locations, card.ability.extra.id) then

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -1184,6 +1184,7 @@ function Card:set_ability(center, initial, delay_sprites)
 			
 			if _hint then
 				if not G.AP.hint_locations[G.AP.hints[i].location] then
+					if not G.E_MANAGER.queues.ap_hints then G.E_MANAGER.queues.ap_hints = {} end
 					G.AP.hint_priotiy = G.AP.hint_priotiy or {}
 					G.AP.hint_priotiy[G.AP.hints[i].location] = _hint
 					G.AP.make_hint_step(nil, _hint)

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -1889,19 +1889,19 @@ SMODS.Consumable {
 }
 
 G.AP.location_seen = function(id)
-	local make_hint = true
-	if G.AP.hints then
-		for i = 1, #G.AP.hints do
-			if G.AP.hints[i].location == id then
-				make_hint = false
-			end
-		end
-	end
+	-- local make_hint = true
+	--if G.AP.hints then
+		--for i = 1, #G.AP.hints do
+			--if G.AP.hints[i].location == id then
+				--make_hint = false
+			--end
+		--end
+	--end
 	
-	if make_hint then
+	--if make_hint then
 		G.APClient:LocationScouts({id}, 2)
-		G.APClient:Get({"_read_hints_"..tostring(G.AP.team_id).."_"..tostring(G.AP.player_id)})
-	end
+		--G.APClient:Get({"_read_hints_"..tostring(G.AP.team_id).."_"..tostring(G.AP.player_id)})
+	--end
 end
 
 function get_tarot_location(_pool_length)

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -1183,10 +1183,10 @@ function Card:set_ability(center, initial, delay_sprites)
 			end
 			
 			if _hint then
-				if not G.AP.hint_locations[G.AP.hints[i].location] then
+				if not G.AP.hint_locations[_hint.location] then
 					if not G.E_MANAGER.queues.ap_hints then G.E_MANAGER.queues.ap_hints = {} end
 					G.AP.hint_priotiy = G.AP.hint_priotiy or {}
-					G.AP.hint_priotiy[G.AP.hints[i].location] = _hint
+					G.AP.hint_priotiy[_hint.location] = _hint
 					G.AP.make_hint_step(nil, _hint)
 				end
 			end


### PR DESCRIPTION
- Fixed a crash related to item names on AP checks
- Fixed a crash with The Fool when copying an AP consumable
- Main Menu will now show locked cards with hints
- Magic Deck's Fools and Ghost Deck's Hex will now spawn undebuffed even if you don't have those cards unlocked.