### PR TITLE
0.1.9d

### DIFF
--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -544,51 +544,12 @@ function APConnect()
         end
 
         G.APClient:ConnectUpdate(nil, tags)
-        -- print("Players:")
-        -- local players = G.APClient:get_players()
-        -- for _, player in ipairs(players) do
-        --     print("  " .. tostring(player.slot) .. ": " .. player.name .. " playing " ..
-        --               G.APClient:get_player_game(player.slot))
-        -- end
-
-        -- local seed = G.APClient:get_seed()
-		-- local seed_mismatch = false
-        -- local clientSeed = nil
-        -- local info = get_compressed(G.AP.profile_Id .. '/profile.jkr')
-        -- if info then
-            -- local unpacked = STR_UNPACK(info)
-            -- clientSeed = unpacked['ap_seed']
-        -- end
-
-        -- if not clientSeed then
-            -- G.PROFILES[G.AP.profile_Id]['ap_seed'] = seed
-        -- else
-            -- if clientSeed ~= seed then
-                -- sendDebugMessage("Client and Server have different seeds")
-				-- seed_mismatch = true
-				
-				-- love.filesystem.remove(G.AP.profile_Id..'/'..'profile.jkr')
-				-- love.filesystem.remove(G.AP.profile_Id..'/'..'save.jkr')
-				-- love.filesystem.remove(G.AP.profile_Id..'/'..'meta.jkr')
-				-- love.filesystem.remove(G.AP.profile_Id..'/'..'unlock_notify.jkr')
-				-- love.filesystem.remove(G.AP.profile_Id..'')
-				-- G.SAVED_GAME = nil
-				-- G.DISCOVER_TALLIES = nil
-				-- G.PROGRESS = nil
-				-- G.PROFILES[G.AP.profile_Id] = {}
-				
-				-- G.FUNCS.APDisconnect()
-            -- end
-        -- end
 		
-		-- set profile name to slot name 
-		--G.PROFILES[G.AP.profile_Id]['name'] = G.AP['APSlot']
 		-- just to make sure it's actually loading the right profile
 		G.SETTINGS.profile = G.AP.profile_Id
 		
 		-- wrong seed will wipe the AP profile (all needed data is serverside)
 		G.FUNCS.load_profile(false)
-		
 		G.FUNCS.set_up_APProfile()
     end
 
@@ -1772,11 +1733,6 @@ G.FUNCS.load_profile = function(delete_prof_data)
 			no_delete = true,
 			func = function()
 				G:delete_run()
-				local _name = nil
-				if G.PROFILES[G.focused_profile].name and G.PROFILES[G.focused_profile].name ~= '' then
-				_name = G.PROFILES[G.focused_profile].name
-				end
-				if delete_prof_data then G.PROFILES[G.focused_profile] = {} end
 				G.DISCOVER_TALLIES = nil
 				G.PROGRESS = nil
 				G.AP.load_profile()
@@ -1803,7 +1759,7 @@ G.FUNCS.load_profile = function(delete_prof_data)
 end
 
 G.AP.load_profile = function()
-	local temp_profile = {
+	local temp_APprofile = {
 		MEMORY = {
 			deck = 'Red Deck',
 			stake = 1,
@@ -1860,7 +1816,9 @@ G.AP.load_profile = function()
 		unlocked = {}
 		}
 	}
-	G.PROFILES[G.AP.profile_Id] = temp_profile
+	G.PROFILES[G.AP.profile_Id] = temp_APprofile
+	G.PROFILES[G.AP.profile_Id].init = true
+	G.FUNCS.set_up_APProfile()
 end
 
 local CanContinueRef = G.FUNCS.can_continue

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -514,7 +514,12 @@ function APConnect()
         print("Socket error: " .. msg)
         connection_attempts = connection_attempts + 1
         if connection_attempts >= 3 then
-            G.FUNCS.APDisconnect()
+			if not isAPProfileLoaded() then
+				G.FUNCS.APDisconnect()
+				unloadAPProfile = false
+			else
+				G.APClient = nil
+			end
         end
     end
 

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -724,7 +724,7 @@ function APConnect()
                                 ease_discard(1)
                             end
 
-                            notify_alert('op_discard', "Bonus")
+                            if notify then notify_alert('op_discard', "Bonus") end
                         else
                             G.AP.BonusQueue[#G.AP.BonusQueue + 1] = {
                                 type = "bonusdiscards",
@@ -741,7 +741,7 @@ function APConnect()
                                 ease_dollars(1, true)
                             end
 
-                            notify_alert('op_money', "Bonus")
+                            if notify then notify_alert('op_money', "Bonus") end
                         else
                             G.AP.BonusQueue[#G.AP.BonusQueue + 1] = {
                                 type = "bonusstartingmoney",
@@ -759,7 +759,7 @@ function APConnect()
                                 ease_hands_played(1)
                             end
 
-                            notify_alert('op_hand', "Bonus")
+                            if notify then notify_alert('op_hand', "Bonus") end
                         else
                             G.AP.BonusQueue[#G.AP.BonusQueue + 1] = {
                                 type = "bonushands",
@@ -775,7 +775,7 @@ function APConnect()
                                 G.hand:change_size(1)
                             end
 
-                            notify_alert('op_hand_size', "Bonus")
+                            if notify then notify_alert('op_hand_size', "Bonus") end
                         else
                             G.AP.BonusQueue[#G.AP.BonusQueue + 1] = {
                                 type = "bonushandsize",
@@ -796,7 +796,7 @@ function APConnect()
                                 }))
                             end
 
-                            notify_alert('op_interest', "Bonus")
+                            if notify then notify_alert('op_interest', "Bonus") end
                         else
                             G.AP.BonusQueue[#G.AP.BonusQueue + 1] = {
                                 type = "maxinterest",
@@ -819,7 +819,7 @@ function APConnect()
                                 }))
                             end
 
-                            notify_alert('op_joker_slot', "Bonus")
+                            if notify then notify_alert('op_joker_slot', "Bonus") end
                         else
                             G.AP.BonusQueue[#G.AP.BonusQueue + 1] = {
                                 type = "bonusjoker",
@@ -840,7 +840,7 @@ function APConnect()
                                 }))
                             end
 
-                            notify_alert('op_consum_slot', "Bonus")
+                            if notify then notify_alert('op_consum_slot', "Bonus") end
                         else
                             G.AP.BonusQueue[#G.AP.BonusQueue + 1] = {
                                 type = "bonusconsumable",
@@ -855,7 +855,7 @@ function APConnect()
                             local amount = math.random(3, 8)
                             ease_dollars(amount)
 
-                            notify_alert('fill_money', "Bonus")
+                            if notify then notify_alert('fill_money', "Bonus") end
                         end
                     elseif item_id == 311 then
                         -- receive random Joker (must be during a game)
@@ -877,7 +877,7 @@ function APConnect()
                                 }
                             end
 
-                            notify_alert('fill_buffoon', "Bonus")
+                           if notify then notify_alert('fill_buffoon', "Bonus") end
                         end
                     elseif item_id == 312 then
                         -- receive random consumable (must be during a game)
@@ -916,7 +916,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_juggle', "Bonus")
+                            if notify then notify_alert('fill_juggle', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -937,7 +937,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_d_six', "Bonus")
+                            if notify then notify_alert('fill_d_six', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -958,7 +958,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_uncommon', "Bonus")
+                            if notify then notify_alert('fill_uncommon', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -979,7 +979,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_rare', "Bonus")
+                            if notify then notify_alert('fill_rare', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -1000,7 +1000,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_negative', "Bonus")
+                            if notify then notify_alert('fill_negative', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -1021,7 +1021,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_foil', "Bonus")
+                            if notify then notify_alert('fill_foil', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -1042,7 +1042,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_holo', "Bonus")
+                            if notify then notify_alert('fill_holo', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -1063,7 +1063,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_poly', "Bonus")
+                            if notify then notify_alert('fill_poly', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -1084,7 +1084,7 @@ function APConnect()
                                     return true
                                 end)
                             }))
-                            notify_alert('fill_double', "Bonus")
+                            if notify then notify_alert('fill_double', "Bonus") end
 
                             -- spectral gimmick
                             if G.AP.Spectral.active == true and not G.AP.Spectral.item then
@@ -1101,33 +1101,33 @@ function APConnect()
                     if (item_id == 330) then
                         -- Lose All Money
                         ease_dollars(-G.GAME.dollars, true)
-                        notify_alert("t_money", "Trap")
+                        if notify then notify_alert("t_money", "Trap") end
 
                     elseif (item_id == 331) then
                         -- Lose 1 Discard
                         ease_discard(-1)
-                        notify_alert("t_discard", "Trap")
+                        if notify then notify_alert("t_discard", "Trap") end
                     elseif item_id == 332 then
                         -- Lose 1 Hand
                         ease_hands_played(-1)
-                        notify_alert("t_hand", "Trap")
+                        if notify then notify_alert("t_hand", "Trap") end
                     elseif item_id == 333 then
                         -- make joker perishable
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_perishable(true)
-                            notify_alert("t_perishable", "Trap")
+                            if notify then notify_alert("t_perishable", "Trap") end
                         end
                     elseif item_id == 334 then
                         -- make joker eternal
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_eternal(true)
-                            notify_alert("t_eternal", "Trap")
+                            if notify then notify_alert("t_eternal", "Trap") end
                         end
                     elseif item_id == 335 then
                         -- make joker rental
                         if G.jokers and #G.jokers.cards > 0 then
                             G.jokers.cards[math.random(#G.jokers.cards)]:set_rental(true)
-                            notify_alert("t_rental", "Trap")
+                            if notify then notify_alert("t_rental", "Trap") end
                         end
                     end
 
@@ -1249,7 +1249,7 @@ function APConnect()
                         if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
                             G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
                             if (G.AP.StakesInit) then
-                                G.FUNCS.AP_unlock_stake('White Stake')
+                                G.FUNCS.AP_unlock_stake('White Stake', notify)
                             else
                                 G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'White Stake'
                             end
@@ -1260,7 +1260,7 @@ function APConnect()
                         if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
                             G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
                             if (G.AP.StakesInit) then
-                                G.FUNCS.AP_unlock_stake('Red Stake')
+                                G.FUNCS.AP_unlock_stake('Red Stake', notify)
                             else
                                 G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Red Stake'
                             end
@@ -1271,7 +1271,7 @@ function APConnect()
                         if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
                             G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
                             if (G.AP.StakesInit) then
-                                G.FUNCS.AP_unlock_stake('Green Stake')
+                                G.FUNCS.AP_unlock_stake('Green Stake', notify)
                             else
                                 G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Green Stake'
                             end
@@ -1282,7 +1282,7 @@ function APConnect()
                         if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
                             G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
                             if (G.AP.StakesInit) then
-                                G.FUNCS.AP_unlock_stake('Black Stake')
+                                G.FUNCS.AP_unlock_stake('Black Stake', notify)
                             else
                                 G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Black Stake'
                             end
@@ -1293,7 +1293,7 @@ function APConnect()
                         if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
                             G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
                             if (G.AP.StakesInit) then
-                                G.FUNCS.AP_unlock_stake('Blue Stake')
+                                G.FUNCS.AP_unlock_stake('Blue Stake', notify)
                             else
                                 G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Blue Stake'
                             end
@@ -1304,7 +1304,7 @@ function APConnect()
                         if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
                             G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
                             if (G.AP.StakesInit) then
-                                G.FUNCS.AP_unlock_stake('Purple Stake')
+                                G.FUNCS.AP_unlock_stake('Purple Stake', notify)
                             else
                                 G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Purple Stake'
                             end
@@ -1315,7 +1315,7 @@ function APConnect()
                         if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
                             G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
                             if (G.AP.StakesInit) then
-                                G.FUNCS.AP_unlock_stake('Orange Stake')
+                                G.FUNCS.AP_unlock_stake('Orange Stake', notify)
                             else
                                 G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Orange Stake'
                             end
@@ -1326,7 +1326,7 @@ function APConnect()
                         if not G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] then
                             G.PROFILES[G.AP.profile_Id]["received_indeces"][item.index] = true
                             if (G.AP.StakesInit) then
-                                G.FUNCS.AP_unlock_stake('Gold Stake')
+                                G.FUNCS.AP_unlock_stake('Gold Stake', notify)
                             else
                                 G.AP.StakeQueue[#G.AP.StakeQueue + 1] = 'Gold Stake'
                             end
@@ -1448,7 +1448,7 @@ function APConnect()
                     end
 
                     if (G.AP.StakesInit) then
-                        G.FUNCS.AP_unlock_stake_per_deck(stake_name, deck_name)
+                        G.FUNCS.AP_unlock_stake_per_deck(stake_name, deck_name, notify)
                     else
                         G.AP.StakeQueue[#G.AP.StakeQueue + 1] = {
                             stake = stake_name,
@@ -1547,6 +1547,7 @@ function APConnect()
 			if isAPProfileLoaded() then
 				if key == "balatro_deck_wins"..tostring(G.AP.player_id)..'_'..tostring(G.AP.team_id) and type(map[key]) == 'table' then 
 					G.PROFILES[G.SETTINGS.profile].deck_usage = map[key]
+					
 					if G.AP.goal ~= 4 then
 						G.PROFILES[G.AP.profile_Id].ap_progress = G.AP.check_progress()
 					end

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1598,8 +1598,9 @@ function APConnect()
 					end
 				end 
 				
-				if key == "balatro_current_run"..tostring(G.AP.player_id)..'_'..tostring(G.AP.team_id) then 
-					G.SAVED_GAME = map[key]
+				if key == "balatro_current_run"..tostring(G.AP.player_id)..'_'..tostring(G.AP.team_id) and type(map[key]) == 'string' then 
+					local decompressed_save = STR_UNPACK(map[key])
+					G.SAVED_GAME = decompressed_save
 				end
 			end
 			
@@ -1912,7 +1913,8 @@ G.AP.server_save_jokers = function()
 end
 
 G.AP.server_save_run = function(data)
-	G.APClient:Set("balatro_current_run"..tostring(G.AP.player_id)..'_'..tostring(G.AP.team_id), {}, false, {{'replace', data}})
+	local compressed_save = STR_PACK(data)
+	G.APClient:Set("balatro_current_run"..tostring(G.AP.player_id)..'_'..tostring(G.AP.team_id), {}, false, {{'replace', compressed_save}})
 end
 
 G.AP.server_load = function()

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1871,7 +1871,8 @@ G.FUNCS.can_continue = function(e)
 			if G.SAVED_GAME and G.SAVED_GAME.GAME then
 				if G.SAVED_GAME.GAME.ap_seed == G.APClient:get_seed() and
 				G.SAVED_GAME.GAME.ap_jokers_removed == AreJokersRemoved() and
-				G.SAVED_GAME.GAME.ap_consums_removed == AreConsumablesRemoved() then
+				G.SAVED_GAME.GAME.ap_consums_removed == AreConsumablesRemoved() and
+				G.SAVED_GAME.GAME.ap_modded_items == G.AP.this_mod.config.modded then
 					_can_continue = true
 				end
 			end

--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1872,7 +1872,7 @@ G.AP.server_save_jokers = function()
 end
 
 G.AP.server_save_run = function(data)
-	local compressed_save = STR_PACK(data)
+	local compressed_save = data and STR_PACK(data) or nil
 	G.APClient:Set("balatro_current_run"..tostring(G.AP.player_id)..'_'..tostring(G.AP.team_id), {}, false, {{'replace', compressed_save}})
 end
 

--- a/lovely.toml
+++ b/lovely.toml
@@ -10,7 +10,7 @@ priority = 0
 target = '=[SMODS _ "src/utils.lua"]'
 pattern = '''function convert_save_data()'''
 position = "after"
-payload = '''if G.PROFILES[G.SETTINGS.profile].ap_seed then return nil end'''
+payload = '''if isAPProfileLoaded and isAPProfileLoaded() then return nil end'''
 match_indent=true
 
 # save run serverside

--- a/lovely.toml
+++ b/lovely.toml
@@ -12,3 +12,15 @@ pattern = '''function convert_save_data()'''
 position = "after"
 payload = '''if G.PROFILES[G.SETTINGS.profile].ap_seed then return nil end'''
 match_indent=true
+
+# save run serverside
+[[patches]]
+[patches.pattern]
+target = 'game.lua'
+pattern = '''if G.FILE_HANDLER.run then'''
+position = "after"
+payload = '''if isAPProfileLoaded() then 
+	G.AP.server_save_run(G.ARGS.save_run) 
+	G.SAVED_GAME = G.ARGS.save_run
+end'''
+match_indent=true

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -471,7 +471,7 @@ end
 
 local game_load_profileRef = Game.load_profile
 function Game:load_profile(_profile)
-	print(tostring(_profile).." "..tostring(isAPProfileLoaded()).." "..tostring(G.AP.GameObjectInit))
+	-- print(tostring(_profile).." "..tostring(isAPProfileLoaded()).." "..tostring(G.AP.GameObjectInit))
     if unloadAPProfile then
         _profile = _profile == G.AP.profile_Id and 1 or _profile
         unloadAPProfile = false
@@ -672,10 +672,14 @@ function Game:init_item_prototypes()
                 -- if not G.PROFILES[G.AP.profile_Id].deck_usage[k].losses_by_key then
                     -- G.PROFILES[G.AP.profile_Id].deck_usage[k].losses_by_key = {}
                 -- end
-                if not G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks then
-                    G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks = {}
+				if not G.PROFILES[G.AP.profile_Id].deck_stake then
+					G.PROFILES[G.AP.profile_Id].deck_stake = {}
+				end
+				
+                if not G.PROFILES[G.AP.profile_Id].deck_stake[k] then
+                    G.PROFILES[G.AP.profile_Id].deck_stake[k] = {}
                     for i = 1, 8, 1 do
-                        G.PROFILES[G.AP.profile_Id].deck_usage[k].stake_unlocks[i] = false
+                        G.PROFILES[G.AP.profile_Id].deck_stake[k][i] = false
                     end
                 end
 

--- a/randomizer.lua
+++ b/randomizer.lua
@@ -187,6 +187,7 @@ function Game:init_game_object()
 		init_game_object.ap_seed = G.APClient:get_seed()
 		init_game_object.ap_jokers_removed = AreJokersRemoved()	
 		init_game_object.ap_consums_removed = AreConsumablesRemoved()
+		init_game_object.ap_modded_items = G.AP.this_mod.config.modded
 
     end
 

--- a/stake.lua
+++ b/stake.lua
@@ -815,7 +815,7 @@ function get_joker_win_sticker(_center, index)
 		if G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key] and G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key].wins then 
 			local _w = 0
 			for k, v in pairs(G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key].wins) do
-			_w = math.max(G.P_CENTER_POOLS.Stake[k].stake_level, _w)
+			_w = math.max(G.P_CENTER_POOLS.Stake[k] and G.P_CENTER_POOLS.Stake[k].stake_level or 0, _w)
 			end
 			if index then return _w end
 			if _w > 0 then return G.sticker_map[_w] end

--- a/stake.lua
+++ b/stake.lua
@@ -787,10 +787,47 @@ function set_deck_win()
             set_challenge_unlock()
             G:save_settings()
 			G.AP.server_save_decks()
+			G.AP.server_save_jokers()
         end
     else
         return set_deck_winRef()
     end
+end
+
+-- Joker stickers!
+local joker_win_Ref = set_joker_win
+function set_joker_win()
+	if isAPProfileLoaded() then
+		for k, v in pairs(G.jokers.cards) do
+			if v.config.center_key and v.ability.set == 'Joker' then
+			G.PROFILES[G.SETTINGS.profile].joker_usage[v.config.center_key] = G.PROFILES[G.SETTINGS.profile].joker_usage[v.config.center_key] or {count = 1, order = v.config.center.order, wins = {}, losses = {}}
+				if G.PROFILES[G.SETTINGS.profile].joker_usage[v.config.center_key] then
+					G.PROFILES[G.SETTINGS.profile].joker_usage[v.config.center_key].wins = G.PROFILES[G.SETTINGS.profile].joker_usage[v.config.center_key].wins or {}
+					G.PROFILES[G.SETTINGS.profile].joker_usage[v.config.center_key].wins[G.GAME.stake] = (G.PROFILES[G.SETTINGS.profile].joker_usage[v.config.center_key].wins[G.GAME.stake] or 0) + 1
+				end
+			end
+		end
+		G:save_settings()
+	else
+		return joker_win_Ref()
+	end
+end
+
+local joker_sticker_Ref = get_joker_win_sticker
+function get_joker_win_sticker(_center, index)
+	if isAPProfileLoaded() then
+		if G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key] and G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key].wins then 
+			local _w = 0
+			for k, v in pairs(G.PROFILES[G.SETTINGS.profile].joker_usage[_center.key].wins) do
+			_w = math.max(G.P_CENTER_POOLS.Stake[k].stake_level, _w)
+			end
+			if index then return _w end
+			if _w > 0 then return G.sticker_map[_w] end
+		end
+		if index then return 0 end
+	else
+		return joker_sticker_Ref(_center, index)
+	end
 end
 
 -- custom stake application cus yay

--- a/stake.lua
+++ b/stake.lua
@@ -1,33 +1,29 @@
-G.FUNCS.AP_unlock_stake = function(stake_name)
+G.FUNCS.AP_unlock_stake = function(stake_name, notify)
     for k, v in ipairs(G.P_CENTER_POOLS.Stake) do
         if (v.name == stake_name) then
             G.PROFILES[G.AP.profile_Id].stake_unlocks[k] = true
             v.unlocked = true
             if G.AP.StakesInit then
-                notify_alert(G.P_CENTER_POOLS.Stake[k].key, 'Stake')
+                if notify then notify_alert(G.P_CENTER_POOLS.Stake[k].key, 'Stake') end
             end
 
         end
     end
 end
 
-G.FUNCS.AP_unlock_stake_per_deck = function(stake_key, deck_key)
+G.FUNCS.AP_unlock_stake_per_deck = function(stake_key, deck_key, notify)
     for k, v in ipairs(G.P_CENTER_POOLS.Stake) do
         if stake_key == nil then
             sendDebugMessage("stake_key is nil, this is bad!")
         end
-
-        if G.PROFILES[G.AP.profile_Id].deck_usage[deck_key] == nil then
-            sendDebugMessage("deck_usage is nil, this is bad!")
-        end
-
+		
         -- check for existence of the deck_usage to avoid crashes when the key is blank
         if (v.key == stake_key) and G.PROFILES[G.AP.profile_Id].deck_usage[deck_key] then
 
-            G.PROFILES[G.AP.profile_Id].deck_usage[deck_key].stake_unlocks[k] = true
+            G.PROFILES[G.AP.profile_Id].deck_stake[deck_key][k] = true
 
             if G.AP.StakesInit then
-                notify_alert(stake_key .. deck_key, 'BackStake')
+                if notify then notify_alert(stake_key .. deck_key, 'BackStake') end
             end
 
         end
@@ -345,9 +341,9 @@ function check_stake_unlock(_stake, _deck_key)
     -- (stakes are unlocked if their entry in deck_usage.stake_unlocks exists and is true)
     -- stakes are items for each deck; the decks themselves are not items
     if tonumber(G.AP.slot_data.stake_unlock_mode) == G.AP.stake_unlock_modes.stake_as_item_per_deck then
-        if G.PROFILES[G.SETTINGS.profile].deck_usage and G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key] and
-            G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key].stake_unlocks then
-            return G.PROFILES[G.SETTINGS.profile].deck_usage[_deck_key].stake_unlocks[_stake] or false
+        if G.PROFILES[G.SETTINGS.profile].deck_stake and G.PROFILES[G.SETTINGS.profile].deck_stake[_deck_key] and
+            G.PROFILES[G.SETTINGS.profile].deck_stake[_deck_key] then
+            return G.PROFILES[G.SETTINGS.profile].deck_stake[_deck_key][_stake] or false
         end
 
     end


### PR DESCRIPTION
- AP profile now uses only the serverside save data
- AP profile doesn't require resetting when joining a different seed
- Current run is now saved on the server
- Prevent players from continuing runs that use different Joker/Consumable settings
- Fixed a crash related to Joker sticker data