### PR TITLE
Set explicit priority

### DIFF
--- a/randomizer.lua
+++ b/randomizer.lua
@@ -3,6 +3,7 @@
 --- MOD_ID: Rando
 --- MOD_AUTHOR: [Burndi, SpaD_Overolls, Myst, Silvris]
 --- MOD_DESCRIPTION: Archipelago Client for Balatro
+--- PRIORITY: 8000
 --- PREFIX: rand
 --- BADGE_COLOR: 4E8BE6
 --- DISPLAY_NAME: Archipelago


### PR DESCRIPTION
Cryptid overrides the "Archipelago" button because Cryptid loads after this mod. By switching the mod load order around, it allows for expected behavior. This change was originally going to be done with a lovely patch with the child mod Pingo, but lovely appears to load mod priorities before performing patches, so this change has to be done on the parent mod.

Number is chosen arbitrarily, this simply needs to be greater than 114.