### PR TITLE
Fix crash case when dying

### DIFF
--- a/ap_connection.lua
+++ b/ap_connection.lua
@@ -1558,7 +1558,7 @@ function APConnect()
 			end 
 			
 			if isAPProfileLoaded() then
-				if key == "balatro_current_run"..tostring(G.AP.player_id)..'_'..tostring(G.AP.team_id) and map[key] ~= "" then 
+				if key == "balatro_current_run"..tostring(G.AP.player_id)..'_'..tostring(G.AP.team_id) and map[key] and map[key] ~= "" then 
 					local decompressed_save = STR_UNPACK(map[key])
 					G.SAVED_GAME = decompressed_save
 				end
@@ -1870,4 +1870,5 @@ G.AP.server_load = function()
 	G.APClient:Get({"balatro_deck_wins"..PID, "balatro_joker_wins"..PID, "balatro_current_run"..PID})
 	G.APClient:SetNotify({"balatro_deck_wins"..PID, "balatro_joker_wins"..PID})
 end
+
 


### PR DESCRIPTION
Fixes #111

It seems apclientpp is getting confused by the nil table key and presumably the C call to turn the json into a DataStorageOperation is failing since there's no actual item in position 2, so use an empty string as the "no save" representation instead

There seems to be another issue (memory leak?) where the game starts to lag heavily after about 5 minutes and uses a ridiculous amount of memory. I've not had the opportunity to investigate this one closely, so no fix for that yet