### PR TITLE
extended_corpus = true

### DIFF
--- a/UIdefinitions.lua
+++ b/UIdefinitions.lua
@@ -526,7 +526,7 @@ function G.UIDEF.profile_option(_profile)
 									prompt_text = localize('k_ap_port'),
 									ref_table = G.AP,
 									ref_value = 'APPort',
-									extended_corpus = false,
+									extended_corpus = true,
 									keyboard_offset = 1,
 									callback = function()
 									end


### PR DESCRIPTION
extended_corpus = false does not include zero, which means a port would need to be actively changed if it picks a bad one for the balatro APworld